### PR TITLE
[Spike] Fix assembly scanning

### DIFF
--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/EndpointConfigurationCustomizationExtensions.cs
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/EndpointConfigurationCustomizationExtensions.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using AcceptanceTesting.Support;
+    using Hosting.Helpers;
+
+    public static class EndpointCustomizationConfigurationExtensions
+    {
+        public static IEnumerable<Type> GetTypesScopedByTestClass(this EndpointCustomizationConfiguration endpointConfiguration)
+        {
+            var assemblyScanner = new AssemblyScanner
+            {
+                //ScanFileSystemAssemblies = false
+            };
+
+            var assemblies = assemblyScanner.GetScannableAssemblies();
+
+            var assembliesToScan = assemblies.Assemblies
+                //exclude acceptance tests by default
+                .Where(a => a != Assembly.GetExecutingAssembly()).ToList();
+            var types = assembliesToScan
+                .SelectMany(a => a.GetTypes());
+
+            types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));
+
+            types = types.Union(endpointConfiguration.TypesToInclude);
+
+            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+        }
+
+        static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
+        {
+            if (rootType == null)
+            {
+                throw new InvalidOperationException("Make sure you nest the endpoint infrastructure inside the TestFixture as nested classes");
+            }
+
+            yield return rootType;
+
+            if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)
+            {
+                yield break;
+            }
+
+            foreach (var nestedType in rootType.GetNestedTypes(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SelectMany(t => GetNestedTypeRecursive(t, builderType)))
+            {
+                yield return nestedType;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/NServiceBus.Persistence.NonDurable.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/NServiceBus.Persistence.NonDurable.AcceptanceTests.csproj
@@ -23,4 +23,8 @@
     <Compile Include="../NServiceBus.AcceptanceTests/**/*.cs" Exclude="../NServiceBus.AcceptanceTests/obj/**/*.*"></Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="\**\EndpointTemplates\EndpointCustomizationConfigurationExtensions.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
In https://github.com/Particular/NServiceBus/pull/6239 we made it possible to turn off assembly scanning the file system, and turned that setting off for all acceptance tests. That causes a problem when used in conjunction with this persistence.

The persistence works by [enabling features](https://github.com/Particular/NServiceBus.Persistence.NonDurable/blob/27d39ea7ce08948a7a3fc7531e0ba14b24f47b0f/src/NServiceBus.Persistence.NonDurable/NonDurablePersistence.cs)

The change to the assembly scanning means that these feature types are not included in the list of scanned types.

Unfortunately [this means the features will not be picked up by the feature component](https://github.com/Particular/NServiceBus/blob/b4b0ef5a73e14b6a8e92d83d6ed30919bc16d9a5/src/NServiceBus.Core/Features/FeatureComponent.cs#L21-L24).

This manifests as an exception when starting endpoints in the tests that looks like this:

```
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
   at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
   at NServiceBus.Features.MessageDrivenSubscriptions.<>c__DisplayClass2_0.<Setup>b__3(IServiceProvider b) in /_/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs:line 67
   at NServiceBus.Pipeline.PipelineSettings.<>c__DisplayClass11_0`1.<Register>b__0(IServiceProvider b) in /_/src/NServiceBus.Core/Pipeline/PipelineSettings.cs:line 180
   at NServiceBus.Pipeline.RegisterStep.CreateBehavior(IServiceProvider defaultBuilder) in /_/src/NServiceBus.Core/Pipeline/RegisterStep.cs:line 147
   at NServiceBus.Pipeline`1.<>c__DisplayClass0_0.<.ctor>b__0(RegisterStep r) in /_/src/NServiceBus.Core/Pipeline/Pipeline.cs:line 27
   at System.Linq.Enumerable.SelectListIterator`2.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at NServiceBus.Pipeline`1..ctor(IServiceProvider builder, PipelineModifications pipelineModifications) in /_/src/NServiceBus.Core/Pipeline/Pipeline.cs:line 41
   at NServiceBus.PipelineComponent.CreatePipeline[T](IServiceProvider builder) in /_/src/NServiceBus.Core/Pipeline/PipelineComponent.cs:line 32
   at NServiceBus.SendComponent.CreateMessageOperations(IServiceProvider builder, PipelineComponent pipelineComponent) in /_/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs:line 38
   at NServiceBus.StartableEndpoint.<Start>d__1.MoveNext() in /_/src/NServiceBus.Core/StartableEndpoint.cs:line 38
...
TRUNCATED
```

This is happening because although the persistence sets up the `NonDurableSubscriptionPersistence` feature, it is not being activated.

