### PR TITLE
Revert "Add  metadata component package yml"

### DIFF
--- a/.component-package.yml
+++ b/.component-package.yml
@@ -1,3 +1,0 @@
-ComponentType: Persistence
-ComponentPackages:
-  - Name: NServiceBus.Persistence.NonDurable


### PR DESCRIPTION
Reverts Particular/NServiceBus.Persistence.NonDurable#395

Reverting this PR as component packages that are generated as part of the assets in release work flow will be read from centralized file