### PR TITLE
Prepare for NServiceBus 10 - Remove LangVersion

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,9 +1,9 @@
-<Project>
+﻿<Project>
 
   <PropertyGroup>
     <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    <LangVersion>preview</LangVersion>
+    
   </PropertyGroup>
 
 </Project>

--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinVerMinimumMajorMinor>3.0</MinVerMinimumMajorMinor>
     <MinVerAutoIncrement>minor</MinVerAutoIncrement>
-    
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Now that .NET 10 RC1 has been released, we don't need to set the language anymore.