### PR TITLE
API adjustments

### DIFF
--- a/src/NServiceBus.Persistence.NonDurable/NonDurableStorageRuntime.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableStorageRuntime.cs
@@ -12,7 +12,11 @@ static class NonDurableStorageRuntime
     {
         ArgumentNullException.ThrowIfNull(persistenceOptions, nameof(persistenceOptions));
 
-        var storage = persistenceOptions.Storage ?? SharedStorage;
+        var storage = persistenceOptions.Storage
+            ?? (persistenceOptions.TimeProvider != TimeProvider.System
+                ? new NonDurableStorage(new NonDurableStorageOptions { TimeProvider = persistenceOptions.TimeProvider })
+                : null)
+            ?? SharedStorage;
         services.TryAddSingleton(storage);
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -202,8 +202,8 @@ class NonDurableSagaPersister : ISagaPersister
     }
 
     readonly NonDurableSagaOptions options;
-    readonly ConcurrentDictionary<Guid, SagaEntry> sagas = new();
-    readonly ConcurrentDictionary<CorrelationId, Guid> byCorrelationId = new();
+    readonly ConcurrentDictionary<Guid, SagaEntry> sagas;
+    readonly ConcurrentDictionary<CorrelationId, Guid> byCorrelationId;
 
     readonly record struct SaveOperationState(
         ConcurrentDictionary<Guid, SagaEntry> Sagas,


### PR DESCRIPTION
Ensures that overly generic types are not added directly to the NServiceBus namespace which could cause confusion when paired with other components.