### PR TITLE
Align OTel instrumentation with guidance and fix span lifecycle

### DIFF
--- a/src/NServiceBus.Persistence.NonDurable.Tests/OpenTelemetry/When_emitting_persistence_spans.cs
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/OpenTelemetry/When_emitting_persistence_spans.cs
@@ -49,10 +49,22 @@ public class When_emitting_persistence_spans
 
         using (Assert.EnterMultipleScope())
         {
+            // Span names are under test (part of public API)
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaSaveActivityName), Is.True);
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaGetByIdActivityName && Equals(a.GetTagItem("nservicebus.persistence.result"), "hit")), Is.True);
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaUpdateActivityName), Is.True);
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaCompleteActivityName), Is.True);
+
+            // Parent/child linkage — spans should be children of the root activity
+            Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaSaveActivityName && a.ParentId == root.Id), Is.True);
+            Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaGetByIdActivityName && a.ParentId == root.Id), Is.True);
+
+            // Status deferred to transaction commit (option b) — should be Ok after commit
+            Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaSaveActivityName && a.Status == ActivityStatusCode.Ok), Is.True);
+            Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaUpdateActivityName && a.Status == ActivityStatusCode.Ok), Is.True);
+            Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaCompleteActivityName && a.Status == ActivityStatusCode.Ok), Is.True);
+
+            // Transaction lifecycle events
             Assert.That(activities.Any(a => a.Events.Any(e => e.Name == "nondurable.persistence.transaction.enlisted")), Is.True);
             Assert.That(activities.Any(a => a.Events.Any(e => e.Name == "nondurable.persistence.transaction.committed")), Is.True);
         }
@@ -83,6 +95,9 @@ public class When_emitting_persistence_spans
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.OutboxStoreActivityName), Is.True);
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.OutboxGetActivityName && Equals(a.GetTagItem("nservicebus.persistence.result"), "hit")), Is.True);
             Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.OutboxSetAsDispatchedActivityName && a.Events.Any(e => e.Name == "nondurable.persistence.marked_dispatched")), Is.True);
+
+            // Store span status deferred to outbox transaction commit
+            Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.OutboxStoreActivityName && a.Status == ActivityStatusCode.Ok), Is.True);
         }
     }
 
@@ -119,7 +134,8 @@ public class When_emitting_persistence_spans
         var transaction = new NonDurableStorageTransaction();
         using var root = StartRootActivity();
 
-        transaction.Enlist(new object(), static _ => { });
+        // The activity is passed explicitly to Enlist (no Activity.Current reliance).
+        transaction.Enlist(new object(), static _ => { }, activity: root);
         transaction.Enlist(new InvalidOperationException("boom"), static state => throw state);
 
         Assert.Throws<InvalidOperationException>(() => transaction.Commit());
@@ -127,6 +143,29 @@ public class When_emitting_persistence_spans
         root.Stop();
 
         Assert.That(root.Events.Any(e => e.Name == "nondurable.persistence.transaction.rolled_back"), Is.True);
+    }
+
+    [Test]
+    public async Task Should_mark_enlisted_span_as_error_when_transaction_abandoned()
+    {
+        var persister = new NonDurableSagaPersister();
+        using var listener = new TestingActivityListener(NonDurablePersistenceTracing.ActivitySourceName);
+        using var root = StartRootActivity();
+        var session = new NonDurableSynchronizedStorageSession();
+        var context = new ContextBag();
+        var sagaData = new TestSagaData { Id = Guid.NewGuid(), Value = "first" };
+
+        // Open + Save enlists an activity, but do NOT call CompleteAsync.
+        // Disposing the session should dispose the activity with Error status.
+        await session.Open(context);
+        await persister.Save(sagaData, SagaCorrelationProperty.None, session, context);
+        session.Dispose();
+        root.Stop();
+
+        var activities = listener.CompletedFrom(NonDurablePersistenceTracing.ActivitySourceName);
+
+        Assert.That(activities.Any(a => a.OperationName == NonDurablePersistenceTracing.SagaSaveActivityName
+                                        && a.Status == ActivityStatusCode.Error), Is.True);
     }
 
     static Activity StartRootActivity()

--- a/src/NServiceBus.Persistence.NonDurable/NonDurablePersistenceTracing.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurablePersistenceTracing.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus;
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using Unicast.Subscriptions;
 using Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -57,102 +56,198 @@ static class NonDurablePersistenceTracing
 
     public static bool HasListeners() => activitySource.HasListeners();
 
-    public static Activity? StartSagaGetById(Guid sagaId) => StartActivity(
-        SagaGetByIdActivityName,
-        SagaType,
-        "get",
-        "saga",
-        new TagList
+    public static Activity? StartSagaGetById(Guid sagaId)
+    {
+        if (!activitySource.HasListeners())
         {
-            { LookupTag, "id" },
-            { SagaIdTag, sagaId.ToString() }
-        });
+            return null;
+        }
 
-    public static Activity? StartSagaGetByProperty(Type sagaType, string propertyName, object propertyValue) => StartActivity(
-        SagaGetByPropertyActivityName,
-        SagaType,
-        "get",
-        "saga",
-        new TagList
+        return StartActivity(
+            SagaGetByIdActivityName,
+            SagaType,
+            "get",
+            "saga",
+            new TagList
+            {
+                { LookupTag, "id" },
+                { SagaIdTag, sagaId.ToString() }
+            });
+    }
+
+    public static Activity? StartSagaGetByProperty(Type sagaType, string propertyName, object propertyValue)
+    {
+        if (!activitySource.HasListeners())
         {
-            { LookupTag, propertyName },
-            { MessageTypeTag, sagaType.FullName },
-            { ResultTag, propertyValue?.ToString() }
-        });
+            return null;
+        }
 
-    public static Activity? StartSagaSave(Guid sagaId) => StartActivity(
-        SagaSaveActivityName,
-        SagaType,
-        "save",
-        "saga",
-        new TagList { { SagaIdTag, sagaId.ToString() } });
+        return StartActivity(
+            SagaGetByPropertyActivityName,
+            SagaType,
+            "get",
+            "saga",
+            new TagList
+            {
+                { LookupTag, propertyName },
+                { MessageTypeTag, sagaType.FullName },
+                { ResultTag, propertyValue?.ToString() }
+            });
+    }
 
-    public static Activity? StartSagaUpdate(Guid sagaId) => StartActivity(
-        SagaUpdateActivityName,
-        SagaType,
-        "update",
-        "saga",
-        new TagList { { SagaIdTag, sagaId.ToString() } });
-
-    public static Activity? StartSagaComplete(Guid sagaId) => StartActivity(
-        SagaCompleteActivityName,
-        SagaType,
-        "complete",
-        "saga",
-        new TagList { { SagaIdTag, sagaId.ToString() } });
-
-    public static Activity? StartOutboxBeginTransaction() => StartActivity(
-        OutboxBeginTransactionActivityName,
-        OutboxType,
-        "begin_transaction",
-        "outbox",
-        []);
-
-    public static Activity? StartOutboxGet(string messageId) => StartActivity(
-        OutboxGetActivityName,
-        OutboxType,
-        "get",
-        "outbox",
-        new TagList { { OutboxMessageIdTag, messageId } });
-
-    public static Activity? StartOutboxStore(string messageId, int operationCount) => StartActivity(
-        OutboxStoreActivityName,
-        OutboxType,
-        "store",
-        "outbox",
-        new TagList
+    public static Activity? StartSagaSave(Guid sagaId)
+    {
+        if (!activitySource.HasListeners())
         {
-            { OutboxMessageIdTag, messageId },
-            { CountTag, operationCount }
-        });
+            return null;
+        }
 
-    public static Activity? StartOutboxSetAsDispatched(string messageId) => StartActivity(
-        OutboxSetAsDispatchedActivityName,
-        OutboxType,
-        "set_dispatched",
-        "outbox",
-        new TagList { { OutboxMessageIdTag, messageId } });
+        return StartActivity(
+            SagaSaveActivityName,
+            SagaType,
+            "save",
+            "saga",
+            new TagList { { SagaIdTag, sagaId.ToString() } });
+    }
 
-    public static Activity? StartSubscriptionSubscribe(Subscriber subscriber, MessageType messageType) => StartActivity(
-        SubscriptionSubscribeActivityName,
-        SubscriptionType,
-        "subscribe",
-        "subscription",
-        CreateSubscriptionTags(subscriber, messageType));
+    public static Activity? StartSagaUpdate(Guid sagaId)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
 
-    public static Activity? StartSubscriptionUnsubscribe(Subscriber subscriber, MessageType messageType) => StartActivity(
-        SubscriptionUnsubscribeActivityName,
-        SubscriptionType,
-        "unsubscribe",
-        "subscription",
-        CreateSubscriptionTags(subscriber, messageType));
+        return StartActivity(
+            SagaUpdateActivityName,
+            SagaType,
+            "update",
+            "saga",
+            new TagList { { SagaIdTag, sagaId.ToString() } });
+    }
 
-    public static Activity? StartGetSubscribers(int messageTypesCount) => StartActivity(
-        SubscriptionGetSubscribersActivityName,
-        SubscriptionType,
-        "get_subscribers",
-        "subscription",
-        new TagList { { CountTag, messageTypesCount } });
+    public static Activity? StartSagaComplete(Guid sagaId)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            SagaCompleteActivityName,
+            SagaType,
+            "complete",
+            "saga",
+            new TagList { { SagaIdTag, sagaId.ToString() } });
+    }
+
+    public static Activity? StartOutboxBeginTransaction()
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            OutboxBeginTransactionActivityName,
+            OutboxType,
+            "begin_transaction",
+            "outbox",
+            []);
+    }
+
+    public static Activity? StartOutboxGet(string messageId)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            OutboxGetActivityName,
+            OutboxType,
+            "get",
+            "outbox",
+            new TagList { { OutboxMessageIdTag, messageId } });
+    }
+
+    public static Activity? StartOutboxStore(string messageId, int operationCount)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            OutboxStoreActivityName,
+            OutboxType,
+            "store",
+            "outbox",
+            new TagList
+            {
+                { OutboxMessageIdTag, messageId },
+                { CountTag, operationCount }
+            });
+    }
+
+    public static Activity? StartOutboxSetAsDispatched(string messageId)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            OutboxSetAsDispatchedActivityName,
+            OutboxType,
+            "set_dispatched",
+            "outbox",
+            new TagList { { OutboxMessageIdTag, messageId } });
+    }
+
+    public static Activity? StartSubscriptionSubscribe(Subscriber subscriber, MessageType messageType)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            SubscriptionSubscribeActivityName,
+            SubscriptionType,
+            "subscribe",
+            "subscription",
+            CreateSubscriptionTags(subscriber, messageType));
+    }
+
+    public static Activity? StartSubscriptionUnsubscribe(Subscriber subscriber, MessageType messageType)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            SubscriptionUnsubscribeActivityName,
+            SubscriptionType,
+            "unsubscribe",
+            "subscription",
+            CreateSubscriptionTags(subscriber, messageType));
+    }
+
+    public static Activity? StartGetSubscribers(int messageTypesCount)
+    {
+        if (!activitySource.HasListeners())
+        {
+            return null;
+        }
+
+        return StartActivity(
+            SubscriptionGetSubscribersActivityName,
+            SubscriptionType,
+            "get_subscribers",
+            "subscription",
+            new TagList { { CountTag, messageTypesCount } });
+    }
 
     public static void AddTransactionEnlistedEvent(Activity? activity, string operationType)
     {
@@ -229,10 +324,9 @@ static class NonDurablePersistenceTracing
         }
 
         activity.SetStatus(ActivityStatusCode.Ok);
-        activity.SetTag("otel.status_code", "OK");
     }
 
-    public static void MarkError(Activity? activity, Exception ex, bool exceptionEscaped = true)
+    public static void MarkError(Activity? activity, Exception ex, bool exceptionEscaped)
     {
         if (activity == null)
         {
@@ -240,16 +334,33 @@ static class NonDurablePersistenceTracing
         }
 
         activity.SetStatus(ActivityStatusCode.Error, ex.Message);
-        activity.SetTag("otel.status_code", "ERROR");
-        activity.SetTag("otel.status_description", ex.Message);
-        activity.SetTag(ErrorTypeTag, ex.GetType().Name);
-        activity.AddEvent(new ActivityEvent("exception", DateTimeOffset.UtcNow,
-        [
-            new KeyValuePair<string, object?>("exception.escaped", exceptionEscaped),
-            new KeyValuePair<string, object?>("exception.type", ex.GetType().FullName),
-            new KeyValuePair<string, object?>("exception.message", ex.Message),
-            new KeyValuePair<string, object?>("exception.stacktrace", ex.ToString())
-        ]));
+
+        // Keep the cheap exception attributes always; the stacktrace (ex.ToString()) can be
+        // large, so only materialize it when the span is fully recorded.
+        var exceptionTags = new ActivityTagsCollection
+        {
+            ["exception.escaped"] = exceptionEscaped,
+            ["exception.type"] = ex.GetType().FullName,
+            ["exception.message"] = ex.Message,
+        };
+
+        if (activity.IsAllDataRequested)
+        {
+            exceptionTags["exception.stacktrace"] = ex.ToString();
+        }
+
+        activity.AddEvent(new ActivityEvent("exception", DateTimeOffset.UtcNow, exceptionTags));
+        activity.SetTag(ErrorTypeTag, ex.GetType().FullName);
+    }
+
+    public static void MarkError(Activity? activity, string description)
+    {
+        if (activity == null)
+        {
+            return;
+        }
+
+        activity.SetStatus(ActivityStatusCode.Error, description);
     }
 
     static Activity? StartActivity(string activityName, string persistenceType, string operation, string entity, TagList additionalTags)
@@ -278,7 +389,7 @@ static class NonDurablePersistenceTracing
             return null;
         }
 
-        activity.DisplayName = operation;
+        activity.DisplayName = $"{entity} {operation}";
         activity.Start();
         return activity;
     }

--- a/src/NServiceBus.Persistence.NonDurable/NonDurablePersistenceTracing.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurablePersistenceTracing.cs
@@ -8,7 +8,7 @@ using Unicast.Subscriptions.MessageDrivenSubscriptions;
 
 static class NonDurablePersistenceTracing
 {
-    public const string ActivitySourceName = "NServiceBus.NonDurable";
+    public const string ActivitySourceName = "NServiceBus.Persistence.NonDurable";
 
     public const string SagaGetByIdActivityName = "NServiceBus.NonDurable.Persistence.Saga.GetById";
     public const string SagaGetByPropertyActivityName = "NServiceBus.NonDurable.Persistence.Saga.GetByProperty";

--- a/src/NServiceBus.Persistence.NonDurable/NonDurableStorageTransaction.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableStorageTransaction.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 class NonDurableStorageTransaction
 {
-    public void Enlist<TState>(TState state, Action<TState> apply, Action<TState>? rollback = null)
+    public void Enlist<TState>(TState state, Action<TState> apply, Action<TState>? rollback = null, Activity? activity = null)
     {
         ArgumentNullException.ThrowIfNull(apply);
         var operation = new TransactionOperation<TState>(state, apply, rollback);
@@ -17,7 +17,15 @@ class NonDurableStorageTransaction
             rollbackOperations.Add(operation);
         }
 
-        tracingActivity ??= Activity.Current;
+        // The activity is passed explicitly by the persister (the span owner), never
+        // captured from Activity.Current — user code can replace Activity.Current via
+        // AsyncLocal, so relying on it would capture the wrong span.
+        if (activity is not null)
+        {
+            enlistedActivities.Add(activity);
+        }
+
+        tracingActivity ??= activity;
         NonDurablePersistenceTracing.AddTransactionEnlistedEvent(tracingActivity, typeof(TState).Name);
     }
 
@@ -41,12 +49,14 @@ class NonDurableStorageTransaction
 
             Volatile.Write(ref committed, 1);
             NonDurablePersistenceTracing.AddTransactionCommittedEvent(tracingActivity, operationCount);
+            CompleteEnlistedActivities(success: true);
         }
-        catch
+        catch (Exception ex)
         {
             RollbackAppliedOperations();
 
             NonDurablePersistenceTracing.AddTransactionRolledBackEvent(tracingActivity, operationCount);
+            CompleteEnlistedActivities(success: false, exception: ex);
             throw;
         }
     }
@@ -66,7 +76,59 @@ class NonDurableStorageTransaction
         }
 
         NonDurablePersistenceTracing.AddTransactionRolledBackEvent(tracingActivity, operationCount);
+        CompleteEnlistedActivities(success: false);
         enlistedOperations.Clear();
+    }
+
+    // Called by NonDurableSynchronizedStorageSession.Dispose / NonDurableOutboxTransaction.Dispose
+    // when the transaction was abandoned without Commit or Rollback (e.g. handler failure in the
+    // non-DTC path). Disposes tracked activities to avoid leaks. In the DTC path, the ambient
+    // transaction drives Commit/Rollback via EnlistmentNotification, so this is not called for
+    // enlisted-in-ambient sessions (the session checks enlistedInAmbientTransaction before calling).
+    internal void DisposeTrackedActivities()
+    {
+        if (enlistedActivities.Count == 0)
+        {
+            return;
+        }
+
+        // Transaction was abandoned without commit — mark activities as error and dispose.
+        foreach (var activity in enlistedActivities)
+        {
+            NonDurablePersistenceTracing.MarkError(activity, "Transaction abandoned without commit");
+            activity.Dispose();
+        }
+
+        enlistedActivities.Clear();
+    }
+
+    void CompleteEnlistedActivities(bool success, Exception? exception = null)
+    {
+        if (enlistedActivities.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var activity in enlistedActivities)
+        {
+            if (success)
+            {
+                NonDurablePersistenceTracing.MarkSuccess(activity);
+            }
+            else if (exception is not null)
+            {
+                // The exception escaped the span boundary — Commit rethrows after this.
+                NonDurablePersistenceTracing.MarkError(activity, exception, exceptionEscaped: true);
+            }
+            else
+            {
+                NonDurablePersistenceTracing.MarkError(activity, "Transaction rolled back");
+            }
+
+            activity.Dispose();
+        }
+
+        enlistedActivities.Clear();
     }
 
     void RollbackAppliedOperations()
@@ -80,6 +142,7 @@ class NonDurableStorageTransaction
     readonly List<ITransactionOperation> enlistedOperations = [];
     readonly List<ITransactionOperation> rollbackOperations = [];
     readonly Stack<ITransactionOperation> appliedOperations = [];
+    readonly List<Activity> enlistedActivities = [];
     Activity? tracingActivity;
     int committed;
     int rollbackWasCalled;

--- a/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxStorage.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxStorage.cs
@@ -43,24 +43,33 @@ class NonDurableOutboxStorage(string endpointName, NonDurableStorage storage) : 
 
     public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
     {
-        using var activity = NonDurablePersistenceTracing.StartOutboxStore(message.MessageId, message.TransportOperations.Length);
-        var storageKey = OutboxStorageKey(message.MessageId);
-        var tx = (NonDurableOutboxTransaction)transaction;
-        var storedAt = storage.TimeProvider.GetUtcNow().UtcDateTime;
-        tx.Enlist(
-            new StoreOperationState(Storage, storageKey, message.MessageId, message.TransportOperations.Select(CopyOperation).ToArray(), storedAt),
-            static state =>
-            {
-                if (!state.Storage.TryAdd(state.StorageKey, new StoredOutboxMessage(state.MessageId, state.TransportOperations) { StoredAt = state.StoredAt }))
+        var activity = NonDurablePersistenceTracing.StartOutboxStore(message.MessageId, message.TransportOperations.Length);
+        try
+        {
+            var storageKey = OutboxStorageKey(message.MessageId);
+            var tx = (NonDurableOutboxTransaction)transaction;
+            var storedAt = storage.TimeProvider.GetUtcNow().UtcDateTime;
+            tx.Enlist(
+                new StoreOperationState(Storage, storageKey, message.MessageId, message.TransportOperations.Select(CopyOperation).ToArray(), storedAt),
+                static state =>
                 {
-                    throw new Exception($"Outbox message with id '{state.MessageId}' is already present in storage.");
-                }
-            },
-            static state => state.Storage.TryRemove(state.StorageKey, out _));
-        NonDurablePersistenceTracing.AddStagedEvent(activity);
-        NonDurablePersistenceTracing.MarkSuccess(activity);
+                    if (!state.Storage.TryAdd(state.StorageKey, new StoredOutboxMessage(state.MessageId, state.TransportOperations) { StoredAt = state.StoredAt }))
+                    {
+                        throw new Exception($"Outbox message with id '{state.MessageId}' is already present in storage.");
+                    }
+                },
+                static state => state.Storage.TryRemove(state.StorageKey, out _),
+                activity);
+            NonDurablePersistenceTracing.AddStagedEvent(activity);
 
-        return Task.CompletedTask;
+            return Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            NonDurablePersistenceTracing.MarkError(activity, ex, exceptionEscaped: true);
+            activity?.Dispose();
+            throw;
+        }
     }
 
     public Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxStorage.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxStorage.cs
@@ -43,6 +43,7 @@ class NonDurableOutboxStorage(string endpointName, NonDurableStorage storage) : 
 
     public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
     {
+        // Disposal must be deferred until the transaction completes or is disposed
         var activity = NonDurablePersistenceTracing.StartOutboxStore(message.MessageId, message.TransportOperations.Length);
         try
         {

--- a/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxTransaction.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxTransaction.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Persistence.NonDurable;
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Outbox;
@@ -9,12 +10,12 @@ class NonDurableOutboxTransaction : IOutboxTransaction
 {
     public NonDurableStorageTransaction? Transaction { get; private set; } = new();
 
-    public void Enlist<TState>(TState state, Action<TState> apply, Action<TState>? rollback = null)
+    public void Enlist<TState>(TState state, Action<TState> apply, Action<TState>? rollback = null, Activity? activity = null)
     {
         ArgumentNullException.ThrowIfNull(apply);
         ArgumentNullException.ThrowIfNull(Transaction);
 
-        Transaction.Enlist(state, apply, rollback);
+        Transaction.Enlist(state, apply, rollback, activity);
     }
 
     public Task Commit(CancellationToken cancellationToken = default)
@@ -25,23 +26,16 @@ class NonDurableOutboxTransaction : IOutboxTransaction
 
     public void Dispose()
     {
-        if (Transaction is null)
+        if (Transaction is { } tx)
         {
-            return;
+            tx.DisposeTrackedActivities();
+            Transaction = null;
         }
-
-        Transaction = null;
     }
 
     public ValueTask DisposeAsync()
     {
-        if (Transaction is null)
-        {
-            return default;
-        }
-
-        Transaction = null;
-
+        Dispose();
         return default;
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -30,45 +30,54 @@ class NonDurableSagaPersister : ISagaPersister
 
     public Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
     {
-        using var activity = NonDurablePersistenceTracing.StartSagaSave(sagaData.Id);
-        var correlationId = correlationProperty != SagaCorrelationProperty.None
-            ? new CorrelationId(sagaData.GetType(), correlationProperty)
-            : NoCorrelationId;
-        var entry = new SagaEntry(sagaData, correlationId, version: 1, options.JsonSerializerOptions);
+        var activity = NonDurablePersistenceTracing.StartSagaSave(sagaData.Id);
+        try
+        {
+            var correlationId = correlationProperty != SagaCorrelationProperty.None
+                ? new CorrelationId(sagaData.GetType(), correlationProperty)
+                : NoCorrelationId;
+            var entry = new SagaEntry(sagaData, correlationId, version: 1, options.JsonSerializerOptions);
 
-        ((NonDurableSynchronizedStorageSession)session).Enlist(
-            new SaveOperationState(sagas, byCorrelationId, sagaData.Id, correlationId, entry),
-            static state =>
-            {
-                if (!state.CorrelationId.Equals(NoCorrelationId)
-                    && !state.ByCorrelationId.TryAdd(state.CorrelationId, state.SagaId))
+            ((NonDurableSynchronizedStorageSession)session).Enlist(
+                new SaveOperationState(sagas, byCorrelationId, sagaData.Id, correlationId, entry),
+                static state =>
                 {
-                    throw new InvalidOperationException($"The saga with the correlation id already exists");
-                }
+                    if (!state.CorrelationId.Equals(NoCorrelationId)
+                        && !state.ByCorrelationId.TryAdd(state.CorrelationId, state.SagaId))
+                    {
+                        throw new InvalidOperationException($"The saga with the correlation id already exists");
+                    }
 
-                if (!state.Sagas.TryAdd(state.SagaId, state.Entry))
+                    if (!state.Sagas.TryAdd(state.SagaId, state.Entry))
+                    {
+                        if (!state.CorrelationId.Equals(NoCorrelationId))
+                        {
+                            state.ByCorrelationId.TryRemove(new KeyValuePair<CorrelationId, Guid>(state.CorrelationId, state.SagaId));
+                        }
+
+                        throw new Exception("A saga with this identifier already exists. This should never happen as saga identifiers are meant to be unique.");
+                    }
+                },
+                static state =>
                 {
+                    state.Sagas.TryRemove(new KeyValuePair<Guid, SagaEntry>(state.SagaId, state.Entry));
+
                     if (!state.CorrelationId.Equals(NoCorrelationId))
                     {
                         state.ByCorrelationId.TryRemove(new KeyValuePair<CorrelationId, Guid>(state.CorrelationId, state.SagaId));
                     }
+                },
+                activity);
+            NonDurablePersistenceTracing.AddStagedEvent(activity);
 
-                    throw new Exception("A saga with this identifier already exists. This should never happen as saga identifiers are meant to be unique.");
-                }
-            },
-            static state =>
-            {
-                state.Sagas.TryRemove(new KeyValuePair<Guid, SagaEntry>(state.SagaId, state.Entry));
-
-                if (!state.CorrelationId.Equals(NoCorrelationId))
-                {
-                    state.ByCorrelationId.TryRemove(new KeyValuePair<CorrelationId, Guid>(state.CorrelationId, state.SagaId));
-                }
-            });
-        NonDurablePersistenceTracing.AddStagedEvent(activity);
-        NonDurablePersistenceTracing.MarkSuccess(activity);
-
-        return Task.CompletedTask;
+            return Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            NonDurablePersistenceTracing.MarkError(activity, ex, exceptionEscaped: true);
+            activity?.Dispose();
+            throw;
+        }
     }
 
     public Task<TSagaData> Get<TSagaData>(Guid sagaId, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
@@ -115,68 +124,86 @@ class NonDurableSagaPersister : ISagaPersister
 
     public Task Update(IContainSagaData sagaData, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
     {
-        using var activity = NonDurablePersistenceTracing.StartSagaUpdate(sagaData.Id);
-        var entry = GetEntry(context, sagaData.Id);
-        var updatedEntry = entry.UpdateTo(sagaData, options.JsonSerializerOptions);
+        var activity = NonDurablePersistenceTracing.StartSagaUpdate(sagaData.Id);
+        try
+        {
+            var entry = GetEntry(context, sagaData.Id);
+            var updatedEntry = entry.UpdateTo(sagaData, options.JsonSerializerOptions);
 
-        ((NonDurableSynchronizedStorageSession)session).Enlist(
-            new UpdateOperationState(sagas, sagaData.Id, entry, updatedEntry),
-            static state =>
-            {
-                if (!state.Sagas.TryUpdate(state.SagaId, state.UpdatedEntry, state.Entry))
+            ((NonDurableSynchronizedStorageSession)session).Enlist(
+                new UpdateOperationState(sagas, sagaData.Id, entry, updatedEntry),
+                static state =>
                 {
-                    throw new Exception($"NonDurableSagaPersister concurrency violation: saga entity Id[{state.SagaId}] was modified by another process.");
-                }
-            },
-            static state =>
-            {
-                // Restore the original entry by reading the live value and swapping it back.
-                // Comparing against the live value (rather than the captured updated entry) keeps
-                // rollback correct under DTC two-phase commit, where the prepare and rollback
-                // phases are driven by the distributed transaction coordinator on a separate thread.
-                if (state.Sagas.TryGetValue(state.SagaId, out var currentEntry))
+                    if (!state.Sagas.TryUpdate(state.SagaId, state.UpdatedEntry, state.Entry))
+                    {
+                        throw new Exception($"NonDurableSagaPersister concurrency violation: saga entity Id[{state.SagaId}] was modified by another process.");
+                    }
+                },
+                static state =>
                 {
-                    state.Sagas.TryUpdate(state.SagaId, state.Entry, currentEntry);
-                }
-            });
-        NonDurablePersistenceTracing.AddStagedEvent(activity);
-        NonDurablePersistenceTracing.MarkSuccess(activity);
+                    // Restore the original entry by reading the live value and swapping it back.
+                    // Comparing against the live value (rather than the captured updated entry) keeps
+                    // rollback correct under DTC two-phase commit, where the prepare and rollback
+                    // phases are driven by the distributed transaction coordinator on a separate thread.
+                    if (state.Sagas.TryGetValue(state.SagaId, out var currentEntry))
+                    {
+                        state.Sagas.TryUpdate(state.SagaId, state.Entry, currentEntry);
+                    }
+                },
+                activity);
+            NonDurablePersistenceTracing.AddStagedEvent(activity);
 
-        return Task.CompletedTask;
+            return Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            NonDurablePersistenceTracing.MarkError(activity, ex, exceptionEscaped: true);
+            activity?.Dispose();
+            throw;
+        }
     }
 
     public Task Complete(IContainSagaData sagaData, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
     {
-        using var activity = NonDurablePersistenceTracing.StartSagaComplete(sagaData.Id);
-        var entry = GetEntry(context, sagaData.Id);
+        var activity = NonDurablePersistenceTracing.StartSagaComplete(sagaData.Id);
+        try
+        {
+            var entry = GetEntry(context, sagaData.Id);
 
-        ((NonDurableSynchronizedStorageSession)session).Enlist(
-            new CompleteOperationState(sagas, byCorrelationId, sagaData.Id, entry),
-            static state =>
-            {
-                if (!state.Sagas.TryRemove(new KeyValuePair<Guid, SagaEntry>(state.SagaId, state.Entry)))
+            ((NonDurableSynchronizedStorageSession)session).Enlist(
+                new CompleteOperationState(sagas, byCorrelationId, sagaData.Id, entry),
+                static state =>
                 {
-                    throw new Exception("Saga can't be completed as it was updated by another process.");
-                }
+                    if (!state.Sagas.TryRemove(new KeyValuePair<Guid, SagaEntry>(state.SagaId, state.Entry)))
+                    {
+                        throw new Exception("Saga can't be completed as it was updated by another process.");
+                    }
 
-                if (!state.Entry.CorrelationId.Equals(NoCorrelationId))
+                    if (!state.Entry.CorrelationId.Equals(NoCorrelationId))
+                    {
+                        state.ByCorrelationId.TryRemove(new KeyValuePair<CorrelationId, Guid>(state.Entry.CorrelationId, state.SagaId));
+                    }
+                },
+                static state =>
                 {
-                    state.ByCorrelationId.TryRemove(new KeyValuePair<CorrelationId, Guid>(state.Entry.CorrelationId, state.SagaId));
-                }
-            },
-            static state =>
-            {
-                state.Sagas.TryAdd(state.SagaId, state.Entry);
+                    state.Sagas.TryAdd(state.SagaId, state.Entry);
 
-                if (!state.Entry.CorrelationId.Equals(NoCorrelationId))
-                {
-                    state.ByCorrelationId.TryAdd(state.Entry.CorrelationId, state.SagaId);
-                }
-            });
-        NonDurablePersistenceTracing.AddStagedEvent(activity);
-        NonDurablePersistenceTracing.MarkSuccess(activity);
+                    if (!state.Entry.CorrelationId.Equals(NoCorrelationId))
+                    {
+                        state.ByCorrelationId.TryAdd(state.Entry.CorrelationId, state.SagaId);
+                    }
+                },
+                activity);
+            NonDurablePersistenceTracing.AddStagedEvent(activity);
 
-        return Task.CompletedTask;
+            return Task.CompletedTask;
+        }
+        catch (Exception ex)
+        {
+            NonDurablePersistenceTracing.MarkError(activity, ex, exceptionEscaped: true);
+            activity?.Dispose();
+            throw;
+        }
     }
 
     static void SetEntry(ContextBag context, Guid sagaId, SagaEntry value)

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -30,6 +30,7 @@ class NonDurableSagaPersister : ISagaPersister
 
     public Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
     {
+        // Disposal must be deferred until the transaction completes or is disposed
         var activity = NonDurablePersistenceTracing.StartSagaSave(sagaData.Id);
         try
         {
@@ -124,6 +125,7 @@ class NonDurableSagaPersister : ISagaPersister
 
     public Task Update(IContainSagaData sagaData, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
     {
+        // Disposal must be deferred until the transaction completes or is disposed
         var activity = NonDurablePersistenceTracing.StartSagaUpdate(sagaData.Id);
         try
         {
@@ -165,6 +167,7 @@ class NonDurableSagaPersister : ISagaPersister
 
     public Task Complete(IContainSagaData sagaData, ISynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
     {
+        // Disposal must be deferred until the transaction completes or is disposed
         var activity = NonDurablePersistenceTracing.StartSagaComplete(sagaData.Id);
         try
         {

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Persistence.NonDurable;
 
 using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -15,22 +16,25 @@ class NonDurableSynchronizedStorageSession : ICompletableSynchronizedStorageSess
 
     public void Dispose()
     {
-        if (Transaction is null)
+        if (Transaction is { } tx)
         {
-            return;
-        }
+            // In the DTC path, the ambient transaction drives commit/rollback via
+            // EnlistmentNotification — do not dispose activities here; they will be
+            // disposed when the ambient transaction commits/rolls back. When we own
+            // the transaction and it wasn't committed, dispose tracked activities to
+            // avoid leaks (e.g. handler failure in the non-DTC path).
+            if (ownsTransaction && !enlistedInAmbientTransaction)
+            {
+                tx.DisposeTrackedActivities();
+            }
 
-        Transaction = null;
+            Transaction = null;
+        }
     }
 
     public ValueTask DisposeAsync()
     {
-        if (Transaction is null)
-        {
-            return default;
-        }
-
-        Transaction = null;
+        Dispose();
         return default;
     }
 
@@ -99,11 +103,11 @@ class NonDurableSynchronizedStorageSession : ICompletableSynchronizedStorageSess
         return Task.CompletedTask;
     }
 
-    public void Enlist<TState>(TState state, Action<TState> apply, Action<TState>? rollback = null)
+    public void Enlist<TState>(TState state, Action<TState> apply, Action<TState>? rollback = null, Activity? activity = null)
     {
         ArgumentNullException.ThrowIfNull(apply);
         ArgumentNullException.ThrowIfNull(Transaction);
-        Transaction.Enlist(state, apply, rollback);
+        Transaction.Enlist(state, apply, rollback, activity);
     }
 
     bool ownsTransaction;


### PR DESCRIPTION
We reviewed the OTel instrumentation and found a few things worth fixing. The transport repo has a small corresponding change for `exceptionEscaped`.

### Activity source rename (breaking)

The source was `"NServiceBus.NonDurable"`. Too generic now that the transport has its own `"NServiceBus.Transport.NonDurable"`. Renamed to `"NServiceBus.Persistence.NonDurable"`. This is a behavioral breaking change for anyone who hardcoded the old name in `AddSource(...)` calls. That's acceptable because the source is still at version `0.1.0` (pre-1.0.0), which per OTel versioning conventions means the telemetry surface is not yet stable.

### Span status deferred to transaction commit

Enlisted operations (Save, Update, Complete, Outbox.Store) used to call `MarkSuccess` immediately at staging time, before the transaction committed. If the commit later failed (saga concurrency violation, apply callback throwing), the span already reported `Ok`. That's not accurate.

The persister now passes its started activity explicitly to `Enlist`. The transaction owns the lifecycle: on commit success it marks all tracked activities `Ok` and disposes them. On commit failure or rollback it marks them `Error` and disposes them. Read-only operations (Get, Subscribe, etc.) keep the old pattern since they complete synchronously.

I verified the lifecycle against how Core's pipeline interacts with the storage seam. `LoadHandlersConnector` calls `CompleteAsync` on success and `DisposeAsync` on failure. `TransportReceiveToPhysicalMessageConnector` commits or disposes the outbox transaction. The activity disposal aligns in all three paths: outbox (outbox transaction owns lifecycle), DTC (`EnlistmentNotification` drives commit/rollback), and standalone (session owns lifecycle).

### No more Activity.Current reliance

The transaction was doing `tracingActivity = Activity.Current` to capture the ambient activity for transaction events. User code can replace `Activity.Current` via `AsyncLocal`, so relying on it captures the wrong span. Now the persister passes its captured activity reference explicitly to `Enlist`, and the transaction stores it directly.

### Other changes

- Removed legacy `otel.status_code` and `otel.status_description` tags. `SetStatus` is the modern API, the SDK translates it automatically.
- Added `HasListeners()` guard to every `Start*` method before building the `TagList`, so string allocations like `sagaId.ToString()` don't happen when nobody is listening.
- Guarded `exception.stacktrace` behind `IsAllDataRequested` in `MarkError`. The stacktrace string can be large, so only materialize it when the span is fully recorded.
- Made `exceptionEscaped` a required parameter on `MarkError` (no default). Every call site has to declare whether the exception escaped the span boundary. Changing a default silently broke the dispatcher call site in the transport repo, so removing the default prevents that class of bug.
- Changed `error.type` to use the fully qualified exception name (`FullName` instead of `Name`).
- Improved `DisplayName` from a bare verb ("get", "save") to `"entity operation"` ("saga save", "outbox get").

### Tests

Added parent/child linkage assertions, span status assertions after commit, and a test for span status when a transaction is abandoned without commit (should be `Error`).