### PR TITLE
Support custom finders

### DIFF
--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_using_a_custom_saga_finder.cs
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_using_a_custom_saga_finder.cs
@@ -1,0 +1,129 @@
+namespace NServiceBus.Persistence.NonDurable.AcceptanceTests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using Microsoft.Extensions.DependencyInjection;
+using NServiceBus;
+using NServiceBus.AcceptanceTests;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Extensibility;
+using NServiceBus.Persistence;
+using NServiceBus.Sagas;
+using NUnit.Framework;
+
+public class When_using_a_custom_saga_finder : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_route_message_without_correlation_property_via_finder()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithCustomFinderSaga>(b =>
+            {
+                b.Services(services => services.AddSingleton<ServerTaskIndex>());
+                b.When(session => session.SendLocal(new StartProcessExecution
+                {
+                    ProcessExecutionId = Guid.NewGuid()
+                }));
+            })
+            .Run();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context.SagaIdFromFollowUp, Is.EqualTo(context.SagaIdFromStart));
+            Assert.That(context.ServerTaskIdMatched, Is.True);
+        });
+    }
+
+    // A custom finder that correlates on a non-correlation property cannot query the
+    // in-memory saga dictionary through the synchronized storage session yet, so it keeps a
+    // ServerTaskId -> saga id index and delegates to the persister's by-id Get (which captures
+    // the entry for the optimistic-concurrency check). A projection API that removes the need
+    // for this parallel index is tracked as a follow-up.
+
+    public class Context : ScenarioContext
+    {
+        public Guid SagaIdFromStart { get; set; }
+        public Guid SagaIdFromFollowUp { get; set; }
+        public bool ServerTaskIdMatched { get; set; }
+    }
+
+    public class ServerTaskIndex
+    {
+        public ConcurrentDictionary<Guid, Guid> ServerTaskIdToSagaId { get; } = new();
+    }
+
+    public class EndpointWithCustomFinderSaga : EndpointConfigurationBuilder
+    {
+        public EndpointWithCustomFinderSaga() => EndpointSetup<DefaultServer>();
+
+        public class ProcessExecutionSaga(Context testContext, ServerTaskIndex index) : Saga<ProcessExecutionSagaData>,
+            IAmStartedByMessages<StartProcessExecution>,
+            IHandleMessages<ContinueWithServerTask>
+        {
+            public Task Handle(StartProcessExecution message, IMessageHandlerContext context)
+            {
+                Data.ProcessExecutionId = message.ProcessExecutionId;
+                Data.ServerTaskId = Guid.NewGuid();
+
+                index.ServerTaskIdToSagaId[Data.ServerTaskId] = Data.Id;
+                testContext.SagaIdFromStart = Data.Id;
+
+                return context.SendLocal(new ContinueWithServerTask
+                {
+                    ServerTaskId = Data.ServerTaskId
+                });
+            }
+
+            public Task Handle(ContinueWithServerTask message, IMessageHandlerContext context)
+            {
+                testContext.SagaIdFromFollowUp = Data.Id;
+                testContext.ServerTaskIdMatched = Data.ServerTaskId == message.ServerTaskId;
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ProcessExecutionSagaData> mapper)
+            {
+                mapper.MapSaga(saga => saga.ProcessExecutionId)
+                    .ToMessage<StartProcessExecution>(m => m.ProcessExecutionId);
+
+                mapper.ConfigureFinderMapping<ContinueWithServerTask, ProcessExecutionSagaFinder>();
+            }
+        }
+    }
+
+    public class ProcessExecutionSagaFinder(ISagaPersister persister, ServerTaskIndex index)
+        : ISagaFinder<ProcessExecutionSagaData, ContinueWithServerTask>
+    {
+        public async Task<ProcessExecutionSagaData> FindBy(ContinueWithServerTask message,
+            ISynchronizedStorageSession storageSession, IReadOnlyContextBag context,
+            CancellationToken cancellationToken = default)
+        {
+            if (!index.ServerTaskIdToSagaId.TryGetValue(message.ServerTaskId, out var sagaId))
+            {
+                return null;
+            }
+
+            return await persister.Get<ProcessExecutionSagaData>(sagaId, storageSession, (ContextBag)context, cancellationToken);
+        }
+    }
+
+    public class ProcessExecutionSagaData : ContainSagaData
+    {
+        public Guid ProcessExecutionId { get; set; }
+        public Guid ServerTaskId { get; set; }
+    }
+
+    public class StartProcessExecution : IMessage
+    {
+        public Guid ProcessExecutionId { get; set; }
+    }
+
+    public class ContinueWithServerTask : IMessage
+    {
+        public Guid ServerTaskId { get; set; }
+    }
+}

--- a/src/NServiceBus.Persistence.NonDurable.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.Persistence.NonDurable.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -14,7 +14,7 @@ public partial class PersistenceTestsConfiguration
 
     public bool SupportsOutbox => true;
 
-    public bool SupportsFinders => false;
+    public bool SupportsFinders => true;
 
     public bool SupportsPessimisticConcurrency => false;
 

--- a/src/NServiceBus.Persistence.NonDurable/NonDurablePersistence.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurablePersistence.cs
@@ -10,7 +10,7 @@ public class NonDurablePersistence : PersistenceDefinition, IPersistenceDefiniti
     NonDurablePersistence()
     {
         Defaults(s => s.SetDefault(new NonDurablePersistenceOptions()));
-        Supports<StorageType.Sagas, Features.NonDurableSagaPersistence>();
+        Supports<StorageType.Sagas, Features.NonDurableSagaPersistence>(new StorageType.SagasOptions { SupportsFinders = true });
         Supports<StorageType.Subscriptions, Features.NonDurableSubscriptionPersistence>();
         Supports<StorageType.Outbox, Features.NonDurableOutboxPersistence>();
     }

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -198,8 +198,7 @@ class NonDurableSagaPersister : ISagaPersister
 
         // Custom finders may return saga data that was not loaded via Get, so no entry was
         // captured in the context. Fall back to the current live entry so the optimistic-
-        // concurrency compare still resolves against committed state at the commit
-        // linearization point. The normal Get -> Update path keeps the tighter read-time pin.
+        // concurrency compare still resolves against committed state
         if (sagas.TryGetValue(sagaDataId, out var liveEntry))
         {
             return liveEntry;

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -189,15 +189,22 @@ class NonDurableSagaPersister : ISagaPersister
         entries[sagaId] = value;
     }
 
-    static SagaEntry GetEntry(ContextBag context, Guid sagaDataId)
+    SagaEntry GetEntry(ContextBag context, Guid sagaDataId)
     {
-        if (context.TryGet(ContextKey, out Dictionary<Guid, SagaEntry>? entries))
+        if (context.TryGet(ContextKey, out Dictionary<Guid, SagaEntry>? entries) && entries.TryGetValue(sagaDataId, out var entry))
         {
-            if (entries.TryGetValue(sagaDataId, out var entry))
-            {
-                return entry;
-            }
+            return entry;
         }
+
+        // Custom finders may return saga data that was not loaded via Get, so no entry was
+        // captured in the context. Fall back to the current live entry so the optimistic-
+        // concurrency compare still resolves against committed state at the commit
+        // linearization point. The normal Get -> Update path keeps the tighter read-time pin.
+        if (sagas.TryGetValue(sagaDataId, out var liveEntry))
+        {
+            return liveEntry;
+        }
+
         throw new Exception("The saga should be retrieved with Get method before it's updated.");
     }
 


### PR DESCRIPTION
## What this changes

NonDurable persistence now declares `SagasOptions.SupportsFinders = true` on the saga storage capability. Before this, the feature called `Supports<StorageType.Sagas, NonDurableSagaPersistence>()` without customizing `SagasOptions`, so it inherited the core default of `false`. `SagaComponent.Configure` then threw `"The selected persistence doesn't support custom sagas finders"` at endpoint creation for any saga with a custom finder, even though the runtime persister already implemented the `Get` paths that finders rely on.

## The persister fallback

Flipping the flag on `PersistenceTestsConfiguration.SupportsFinders` un-ignores the shared persistence test `When_updating_saga_with_no_mapping_found_by_finder`. That test returns a pre-supplied saga instance from the finder without calling `persister.Get`, so no `SagaEntry` is captured in the context and `Update` threw `"The saga should be retrieved with Get method before it's updated."`

To handle that, `GetEntry` now falls back to the current live entry when nothing was captured. The normal `Get` to `Update` path keeps the tighter read-time pin: the `SagaEntry` captured at read time is compared against the live one at commit. The fallback only engages when a finder returned saga data without going through `Get`, so it chose not to pin a version. That is the same contract SQL persistence gives when the concurrency token is missing from the context.

## The acceptance test

`When_using_a_custom_saga_finder` reproduces the scenario where a saga's correlation property is `ProcessExecutionId` but a follow-up message carries only `ServerTaskId`. A custom `ProcessExecutionSagaFinder` resolves the saga id from a `ServerTaskId` index and delegates to `persister.Get(sagaId, session, context, ct)`, which captures the entry for the optimistic concurrency check.

## Follow-up

A custom finder that correlates on a non-correlation property still needs its own index today because the synchronized storage session does not expose a queryable view of the saga data. I looked at how SQL persistence solves this with `GetSagaData(whereClause, parameterAppender)` and how the core pipeline trusts the finder result verbatim (no re-`Get` by the framework). The plan for a follow-up is a `GetSagaData(predicate)` extension on `ISynchronizedStorageSession` that returns a deep copy and stamps the `SagaEntry`, so finders correlating on non-correlation properties no longer need a parallel index. 