### PR TITLE
Add saga data projection support to NonDurable storage sessions

### DIFF
--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_persisting_saga_data.cs
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_persisting_saga_data.cs
@@ -25,29 +25,29 @@
 
             Assert.That(context.LoadedSagaData, Is.Not.Null);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.StringArray, Is.EquivalentTo(StringArray));
                 Assert.That(context.LoadedSagaData.Collection, Is.EquivalentTo(Collection));
                 Assert.That(context.LoadedSagaData.List, Is.EquivalentTo(List));
-            });
+            }
 
             Assert.That(context.LoadedSagaData.IntStringDictionary, Has.Count.EqualTo(2));
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.IntStringDictionary[1], Is.EqualTo(IntStringDictionary[1]));
                 Assert.That(context.LoadedSagaData.IntStringDictionary[2], Is.EqualTo(IntStringDictionary[2]));
-            });
+            }
 
             Assert.That(context.LoadedSagaData.StringStringDictionary, Has.Count.EqualTo(2));
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.StringStringDictionary["1"], Is.EqualTo(StringStringDictionary["1"]));
                 Assert.That(context.LoadedSagaData.StringStringDictionary["2"], Is.EqualTo(StringStringDictionary["2"]));
-            });
+            }
 
             Assert.That(context.LoadedSagaData.StringObjectDictionary, Has.Count.EqualTo(2));
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.StringObjectDictionary["obj1"].Guid, Is.EqualTo(StringObjectDictionary["obj1"].Guid));
                 Assert.That(context.LoadedSagaData.StringObjectDictionary["obj1"].Int, Is.EqualTo(StringObjectDictionary["obj1"].Int));
@@ -55,67 +55,67 @@
                 Assert.That(context.LoadedSagaData.StringObjectDictionary["obj2"].Guid, Is.EqualTo(StringObjectDictionary["obj2"].Guid));
                 Assert.That(context.LoadedSagaData.StringObjectDictionary["obj2"].Int, Is.EqualTo(StringObjectDictionary["obj2"].Int));
                 Assert.That(context.LoadedSagaData.StringObjectDictionary["obj2"].String, Is.EqualTo(StringObjectDictionary["obj2"].String));
-            });
+            }
 
             Assert.That(context.LoadedSagaData.ReadOnlyDictionary, Has.Count.EqualTo(2));
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.ReadOnlyDictionary["hello"], Is.EqualTo(ReadOnlyDictionary["hello"]));
                 Assert.That(context.LoadedSagaData.ReadOnlyDictionary["world"], Is.EqualTo(ReadOnlyDictionary["world"]));
-            });
+            }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.DateTimeLocal, Is.EqualTo(DateTimeLocal));
                 Assert.That(context.LoadedSagaData.DateTimeLocal.Kind, Is.EqualTo(DateTimeLocal.Kind));
-            });
+            }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.DateTimeUnspecified, Is.EqualTo(DateTimeUnspecified));
                 Assert.That(context.LoadedSagaData.DateTimeUnspecified.Kind, Is.EqualTo(DateTimeUnspecified.Kind));
-            });
+            }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.DateTimeUtc, Is.EqualTo(DateTimeUtc));
                 Assert.That(context.LoadedSagaData.DateTimeUtc.Kind, Is.EqualTo(DateTimeUtc.Kind));
-            });
+            }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(context.LoadedSagaData.DateTimeOffset, Is.EqualTo(DateTimeOffset));
                 Assert.That(context.LoadedSagaData.DateTimeOffset.Offset, Is.EqualTo(DateTimeOffset.Offset));
                 Assert.That(context.LoadedSagaData.DateTimeOffset.LocalDateTime, Is.EqualTo(DateTimeOffset.LocalDateTime));
-            });
+            }
         }
 
-        static string[] StringArray =
+        static readonly string[] StringArray =
         {
             "a",
             "b",
             "c"
         };
 
-        static Dictionary<int, string> IntStringDictionary = new Dictionary<int, string>
+        static readonly Dictionary<int, string> IntStringDictionary = new()
         {
             {1, "hello"},
             {2, "world"}
         };
 
-        static Dictionary<string, string> StringStringDictionary = new Dictionary<string, string>
+        static readonly Dictionary<string, string> StringStringDictionary = new()
         {
             {"1", "hello"},
             {"2", "world"}
         };
 
-        static IDictionary<int, string> IntStringIDictionary = new Dictionary<int, string>
+        static readonly IDictionary<int, string> IntStringIDictionary = new Dictionary<int, string>
         {
             {1, "hello"},
             {2, "interface world"}
         };
 
-        static Dictionary<string, SamplePoco> StringObjectDictionary = new Dictionary<string, SamplePoco>
+        static readonly Dictionary<string, SamplePoco> StringObjectDictionary = new()
         {
             {
                 "obj1", new SamplePoco
@@ -135,29 +135,29 @@
             }
         };
 
-        static ICollection<string> Collection =
+        static readonly ICollection<string> Collection =
         [
             "1",
             "2"
         ];
 
-        static IList<string> List =
+        static readonly IList<string> List =
         [
             "1",
             "2"
         ];
 
-        static IReadOnlyDictionary<string, int> ReadOnlyDictionary = new ReadOnlyDictionary<string, int>(new Dictionary<string, int>
+        static readonly IReadOnlyDictionary<string, int> ReadOnlyDictionary = new ReadOnlyDictionary<string, int>(new Dictionary<string, int>
         {
             {"hello", 11},
             {"world", 22}
         });
 
-        static DateTime DateTimeLocal = new DateTime(2010, 10, 10, 10, 10, 10, DateTimeKind.Local);
-        static DateTime DateTimeUnspecified = new DateTime(2010, 10, 10, 10, 10, 10, DateTimeKind.Unspecified);
-        static DateTime DateTimeUtc = new DateTime(2010, 10, 10, 10, 10, 10, DateTimeKind.Utc);
+        static readonly DateTime DateTimeLocal = new(2010, 10, 10, 10, 10, 10, DateTimeKind.Local);
+        static readonly DateTime DateTimeUnspecified = new(2010, 10, 10, 10, 10, 10, DateTimeKind.Unspecified);
+        static readonly DateTime DateTimeUtc = new(2010, 10, 10, 10, 10, 10, DateTimeKind.Utc);
 
-        static DateTimeOffset DateTimeOffset = new DateTimeOffset(2010, 10, 10, 10, 10, 10, TimeSpan.FromHours(10));
+        static readonly DateTimeOffset DateTimeOffset = new(2010, 10, 10, 10, 10, 10, TimeSpan.FromHours(10));
 
         public class SamplePoco
         {
@@ -166,13 +166,13 @@
             public Guid Guid { get; set; }
         }
 
-        class Context : ScenarioContext
+        public class Context : ScenarioContext
         {
             public SupportedFieldTypesSagaData LoadedSagaData { get; set; }
             public bool SagaDataLoaded { get; set; }
         }
 
-        class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
         {
             public EndpointThatHostsASaga() => EndpointSetup<DefaultServer>();
 

--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_persisting_saga_data.cs
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_persisting_saga_data.cs
@@ -176,6 +176,7 @@
         {
             public EndpointThatHostsASaga() => EndpointSetup<DefaultServer>();
 
+            [Saga]
             public class SupportedFieldTypesSaga(Context testContext) : Saga<SupportedFieldTypesSagaData>,
                 IAmStartedByMessages<StartSaga>,
                 IHandleMessages<LoadTheSagaAgain>

--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_using_the_synchronized_storage_session_to_find_saga_data.cs
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_using_the_synchronized_storage_session_to_find_saga_data.cs
@@ -1,11 +1,9 @@
 namespace NServiceBus.Persistence.NonDurable.AcceptanceTests;
 
 using System;
-using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using AcceptanceTesting;
-using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
 using NServiceBus.AcceptanceTests;
 using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -14,25 +12,14 @@ using NServiceBus.Persistence;
 using NServiceBus.Sagas;
 using NUnit.Framework;
 
-// This test keeps the explicit ServerTaskId -> saga id index to verify that custom
-// finders can still use their own storage and delegate to the persister's by-id Get
-// (which captures the entry for the optimistic-concurrency check). See
-// When_using_the_synchronized_storage_session_to_find_saga_data for the projection-based
-// finder that queries NonDurable saga data through the synchronized storage session.
-public class When_using_a_custom_saga_finder : NServiceBusAcceptanceTest
+public class When_using_the_synchronized_storage_session_to_find_saga_data : NServiceBusAcceptanceTest
 {
     [Test]
-    public async Task Should_route_message_without_correlation_property_via_finder()
+    public async Task Should_route_message_without_correlation_property_via_projection()
     {
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<EndpointWithCustomFinderSaga>(b =>
-            {
-                b.Services(services => services.AddSingleton<ServerTaskIndex>());
-                b.When(session => session.SendLocal(new StartProcessExecution
-                {
-                    ProcessExecutionId = Guid.NewGuid()
-                }));
-            })
+            .WithEndpoint<EndpointWithProjectionFinderSaga>(b =>
+                b.When(session => session.SendLocal(new StartProcessExecution { ProcessExecutionId = Guid.NewGuid() })))
             .Run();
 
         using (Assert.EnterMultipleScope())
@@ -49,17 +36,12 @@ public class When_using_a_custom_saga_finder : NServiceBusAcceptanceTest
         public bool ServerTaskIdMatched { get; set; }
     }
 
-    public class ServerTaskIndex
+    public class EndpointWithProjectionFinderSaga : EndpointConfigurationBuilder
     {
-        public ConcurrentDictionary<Guid, Guid> ServerTaskIdToSagaId { get; } = new();
-    }
-
-    public class EndpointWithCustomFinderSaga : EndpointConfigurationBuilder
-    {
-        public EndpointWithCustomFinderSaga() => EndpointSetup<DefaultServer>();
+        public EndpointWithProjectionFinderSaga() => EndpointSetup<DefaultServer>();
 
         [Saga]
-        public class ProcessExecutionSaga(Context testContext, ServerTaskIndex index) : Saga<ProcessExecutionSagaData>,
+        public class ProcessExecutionSaga(Context testContext) : Saga<ProcessExecutionSagaData>,
             IAmStartedByMessages<StartProcessExecution>,
             IHandleMessages<ContinueWithServerTask>
         {
@@ -68,7 +50,6 @@ public class When_using_a_custom_saga_finder : NServiceBusAcceptanceTest
                 Data.ProcessExecutionId = message.ProcessExecutionId;
                 Data.ServerTaskId = Guid.NewGuid();
 
-                index.ServerTaskIdToSagaId[Data.ServerTaskId] = Data.Id;
                 testContext.SagaIdFromStart = Data.Id;
 
                 return context.SendLocal(new ContinueWithServerTask
@@ -95,20 +76,15 @@ public class When_using_a_custom_saga_finder : NServiceBusAcceptanceTest
         }
     }
 
-    public class ProcessExecutionSagaFinder(ISagaPersister persister, ServerTaskIndex index)
-        : ISagaFinder<ProcessExecutionSagaData, ContinueWithServerTask>
+    public class ProcessExecutionSagaFinder : ISagaFinder<ProcessExecutionSagaData, ContinueWithServerTask>
     {
-        public async Task<ProcessExecutionSagaData> FindBy(ContinueWithServerTask message,
+        public Task<ProcessExecutionSagaData> FindBy(ContinueWithServerTask message,
             ISynchronizedStorageSession storageSession, IReadOnlyContextBag context,
-            CancellationToken cancellationToken = default)
-        {
-            if (!index.ServerTaskIdToSagaId.TryGetValue(message.ServerTaskId, out var sagaId))
-            {
-                return null;
-            }
-
-            return await persister.Get<ProcessExecutionSagaData>(sagaId, storageSession, (ContextBag)context, cancellationToken);
-        }
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(storageSession.NonDurablePersistenceSession().GetSagaData<ProcessExecutionSagaData>(
+                context,
+                sagaData => sagaData.ServerTaskId == message.ServerTaskId,
+                cancellationToken));
     }
 
     public class ProcessExecutionSagaData : ContainSagaData

--- a/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_using_the_synchronized_storage_session_to_find_saga_data.cs
+++ b/src/NServiceBus.Persistence.NonDurable.AcceptanceTests/When_using_the_synchronized_storage_session_to_find_saga_data.cs
@@ -81,9 +81,10 @@ public class When_using_the_synchronized_storage_session_to_find_saga_data : NSe
         public Task<ProcessExecutionSagaData> FindBy(ContinueWithServerTask message,
             ISynchronizedStorageSession storageSession, IReadOnlyContextBag context,
             CancellationToken cancellationToken = default) =>
-            Task.FromResult(storageSession.NonDurablePersistenceSession().GetSagaData<ProcessExecutionSagaData>(
+            Task.FromResult(storageSession.NonDurablePersistenceSession().GetSagaData<ProcessExecutionSagaData, Guid>(
                 context,
-                sagaData => sagaData.ServerTaskId == message.ServerTaskId,
+                message.ServerTaskId,
+                static (sagaData, serverTaskId) => sagaData.ServerTaskId == serverTaskId,
                 cancellationToken));
     }
 

--- a/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
@@ -30,7 +30,7 @@ namespace NServiceBus
         public NonDurableStorageOptions() { }
         public System.TimeProvider? TimeProvider { get; init; }
     }
-    public static class SynchronizedStorageSessionExtensions
+    public static class NonDurableSynchronizedStorageSessionExtensions
     {
         public static NServiceBus.Persistence.NonDurable.INonDurableStorageSession NonDurablePersistenceSession(this NServiceBus.Persistence.ISynchronizedStorageSession session) { }
     }

--- a/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
@@ -30,12 +30,33 @@ namespace NServiceBus
         public NonDurableStorageOptions() { }
         public System.TimeProvider? TimeProvider { get; init; }
     }
+    public static class SynchronizedStorageSessionExtensions
+    {
+        public static NServiceBus.Persistence.NonDurable.INonDurableStorageSession NonDurablePersistenceSession(this NServiceBus.Persistence.ISynchronizedStorageSession session) { }
+    }
 }
 namespace NServiceBus.Persistence.NonDurable
 {
+    public interface INonDurableStorageSession
+    {
+        TSagaData? GetSagaData<TSagaData>(NServiceBus.Extensibility.IReadOnlyContextBag context, System.Func<TSagaData, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
+            where TSagaData :  class, NServiceBus.IContainSagaData;
+    }
     public static class NonDurableOutboxSettingsExtensions
     {
         public static NServiceBus.Outbox.OutboxSettings FrequencyToRunDeduplicationDataCleanup(this NServiceBus.Outbox.OutboxSettings settings, System.TimeSpan time) { }
         public static NServiceBus.Outbox.OutboxSettings TimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings settings, System.TimeSpan time) { }
+    }
+}
+namespace NServiceBus.Testing
+{
+    public class TestableNonDurableSynchronizedStorageSession : NServiceBus.Persistence.ISynchronizedStorageSession, NServiceBus.Persistence.NonDurable.INonDurableStorageSession
+    {
+        public TestableNonDurableSynchronizedStorageSession() { }
+        public TestableNonDurableSynchronizedStorageSession(NServiceBus.NonDurableStorage storage) { }
+        public void AddSaga<TSagaData>(TSagaData sagaData)
+            where TSagaData :  class, NServiceBus.IContainSagaData { }
+        public TSagaData? GetSagaData<TSagaData>(NServiceBus.Extensibility.IReadOnlyContextBag context, System.Func<TSagaData, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
+            where TSagaData :  class, NServiceBus.IContainSagaData { }
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
@@ -41,6 +41,8 @@ namespace NServiceBus.Persistence.NonDurable
     {
         TSagaData? GetSagaData<TSagaData>(NServiceBus.Extensibility.IReadOnlyContextBag context, System.Func<TSagaData, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
             where TSagaData :  class, NServiceBus.IContainSagaData;
+        TSagaData? GetSagaData<TSagaData, TState>(NServiceBus.Extensibility.IReadOnlyContextBag context, TState state, System.Func<TSagaData, TState, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
+            where TSagaData :  class, NServiceBus.IContainSagaData;
     }
     public static class NonDurableOutboxSettingsExtensions
     {
@@ -57,6 +59,8 @@ namespace NServiceBus.Testing
         public void AddSaga<TSagaData>(TSagaData sagaData)
             where TSagaData :  class, NServiceBus.IContainSagaData { }
         public TSagaData? GetSagaData<TSagaData>(NServiceBus.Extensibility.IReadOnlyContextBag context, System.Func<TSagaData, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
+            where TSagaData :  class, NServiceBus.IContainSagaData { }
+        public TSagaData? GetSagaData<TSagaData, TState>(NServiceBus.Extensibility.IReadOnlyContextBag context, TState state, System.Func<TSagaData, TState, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
             where TSagaData :  class, NServiceBus.IContainSagaData { }
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
@@ -55,9 +55,10 @@ namespace NServiceBus.Testing
     public class TestableNonDurableSynchronizedStorageSession : NServiceBus.Persistence.ISynchronizedStorageSession, NServiceBus.Persistence.NonDurable.INonDurableStorageSession
     {
         public TestableNonDurableSynchronizedStorageSession() { }
+        public TestableNonDurableSynchronizedStorageSession(NServiceBus.NonDurableSagaOptions sagaOptions) { }
         public TestableNonDurableSynchronizedStorageSession(NServiceBus.NonDurableStorage storage) { }
-        public void AddSaga<TSagaData>(TSagaData sagaData)
-            where TSagaData :  class, NServiceBus.IContainSagaData { }
+        public TestableNonDurableSynchronizedStorageSession(NServiceBus.NonDurableStorage storage, NServiceBus.NonDurableSagaOptions sagaOptions) { }
+        public void AddSaga(NServiceBus.IContainSagaData sagaData) { }
         public TSagaData? GetSagaData<TSagaData>(NServiceBus.Extensibility.IReadOnlyContextBag context, System.Func<TSagaData, bool> predicate, System.Threading.CancellationToken cancellationToken = default)
             where TSagaData :  class, NServiceBus.IContainSagaData { }
         public TSagaData? GetSagaData<TSagaData, TState>(NServiceBus.Extensibility.IReadOnlyContextBag context, TState state, System.Func<TSagaData, TState, bool> predicate, System.Threading.CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Persistence.NonDurable/INonDurableStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/INonDurableStorageSession.cs
@@ -25,4 +25,24 @@ public interface INonDurableStorageSession
         Func<TSagaData, bool> predicate,
         CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData;
+
+    /// <summary>
+    /// Finds saga data by querying the NonDurable in-memory saga store and captures the selected entry for optimistic concurrency checks.
+    /// The query is evaluated against a moment-in-time snapshot of the underlying storage as it is enumerated.
+    /// Saga entries added or removed concurrently with the scan may or may not be included in that snapshot.
+    /// Returned saga data is a copy of the stored entry.
+    /// </summary>
+    /// <typeparam name="TSagaData">The saga data type to query.</typeparam>
+    /// <typeparam name="TState">The type of the state passed to the predicate.</typeparam>
+    /// <param name="context">The current context bag.</param>
+    /// <param name="state">The state passed to the predicate.</param>
+    /// <param name="predicate">The predicate used to select the saga data.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The first saga data instance that matches the predicate, or <c>null</c> when no match is found.</returns>
+    TSagaData? GetSagaData<TSagaData, TState>(
+        IReadOnlyContextBag context,
+        TState state,
+        Func<TSagaData, TState, bool> predicate,
+        CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData;
 }

--- a/src/NServiceBus.Persistence.NonDurable/INonDurableStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/INonDurableStorageSession.cs
@@ -1,0 +1,28 @@
+namespace NServiceBus.Persistence.NonDurable;
+
+using System;
+using System.Threading;
+using Extensibility;
+
+/// <summary>
+/// Provides access to NonDurable persistence synchronized storage operations.
+/// </summary>
+public interface INonDurableStorageSession
+{
+    /// <summary>
+    /// Finds saga data by querying the NonDurable in-memory saga store and captures the selected entry for optimistic concurrency checks.
+    /// The query is evaluated against a moment-in-time snapshot of the underlying storage as it is enumerated.
+    /// Saga entries added or removed concurrently with the scan may or may not be included in that snapshot.
+    /// Returned saga data is a copy of the stored entry.
+    /// </summary>
+    /// <typeparam name="TSagaData">The saga data type to query.</typeparam>
+    /// <param name="context">The current context bag.</param>
+    /// <param name="predicate">The predicate used to select the saga data.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>The first saga data instance that matches the predicate, or <c>null</c> when no match is found.</returns>
+    TSagaData? GetSagaData<TSagaData>(
+        IReadOnlyContextBag context,
+        Func<TSagaData, bool> predicate,
+        CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData;
+}

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
@@ -11,6 +11,20 @@ static class NonDurableSagaDataProjection
         IReadOnlyContextBag context,
         Func<TSagaData, bool> predicate,
         CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData =>
+        GetSagaData<TSagaData, Func<TSagaData, bool>>(
+            storage,
+            context,
+            predicate,
+            static (sagaData, predicate) => predicate(sagaData),
+            cancellationToken);
+
+    public static TSagaData? GetSagaData<TSagaData, TState>(
+        NonDurableStorage storage,
+        IReadOnlyContextBag context,
+        TState state,
+        Func<TSagaData, TState, bool> predicate,
+        CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData
     {
         ArgumentNullException.ThrowIfNull(storage);
@@ -32,7 +46,7 @@ static class NonDurableSagaDataProjection
             }
 
             var sagaData = (TSagaData)entry.GetSagaCopy();
-            if (!predicate(sagaData))
+            if (!predicate(sagaData, state))
             {
                 continue;
             }

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
@@ -1,0 +1,46 @@
+namespace NServiceBus.Persistence.NonDurable;
+
+using System;
+using System.Threading;
+using Extensibility;
+
+static class NonDurableSagaDataProjection
+{
+    public static TSagaData? GetSagaData<TSagaData>(
+        NonDurableStorage storage,
+        IReadOnlyContextBag context,
+        Func<TSagaData, bool> predicate,
+        CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        if (context is not ContextBag contextBag)
+        {
+            throw new InvalidOperationException("The context must be a mutable ContextBag.");
+        }
+
+        foreach (var (sagaId, entry) in storage.Sagas)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (entry.SagaDataType != typeof(TSagaData))
+            {
+                continue;
+            }
+
+            var sagaData = (TSagaData)entry.GetSagaCopy();
+            if (!predicate(sagaData))
+            {
+                continue;
+            }
+
+            NonDurableSagaPersister.SetEntry(contextBag, sagaId, entry);
+            return sagaData;
+        }
+
+        return null;
+    }
+}

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -209,7 +209,7 @@ class NonDurableSagaPersister : ISagaPersister
         }
     }
 
-    static void SetEntry(ContextBag context, Guid sagaId, SagaEntry value)
+    internal static void SetEntry(ContextBag context, Guid sagaId, SagaEntry value)
     {
         if (!context.TryGet(ContextKey, out Dictionary<Guid, SagaEntry>? entries))
         {

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaEntry.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaEntry.cs
@@ -11,7 +11,9 @@ class SagaEntry(IContainSagaData sagaData, CorrelationId correlationId, int vers
 
     public int Version { get; } = version;
 
-    public IContainSagaData GetSagaCopy() => (IContainSagaData)Deserialize(serializedSagaData, sagaDataType, serializerOptions);
+    public Type SagaDataType { get; } = sagaData.GetType();
+
+    public IContainSagaData GetSagaCopy() => (IContainSagaData)Deserialize(serializedSagaData, SagaDataType, serializerOptions);
 
     public SagaEntry UpdateTo(IContainSagaData newSagaData, JsonSerializerOptions newSerializerOptions)
         => new(newSagaData, CorrelationId, Version + 1, newSerializerOptions);
@@ -59,6 +61,5 @@ class SagaEntry(IContainSagaData sagaData, CorrelationId correlationId, int vers
         Justification = "Only called when System.Text.Json reflection serialization is enabled.")]
     static object DeserializeWithReflection(string json, Type runtimeType, JsonSerializerOptions options) => JsonSerializer.Deserialize(json, runtimeType, options)!;
 
-    readonly Type sagaDataType = sagaData.GetType();
     readonly string serializedSagaData = Serialize(sagaData, sagaData.GetType(), serializerOptions);
 }

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -118,15 +118,16 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         where TSagaData : class, IContainSagaData =>
         NonDurableSagaDataProjection.GetSagaData(storage, context, predicate, cancellationToken);
 
+    public TSagaData? GetSagaData<TSagaData, TState>(IReadOnlyContextBag context, TState state, Func<TSagaData, TState, bool> predicate, CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData =>
+        NonDurableSagaDataProjection.GetSagaData(storage, context, state, predicate, cancellationToken);
+
     bool ownsTransaction;
     bool enlistedInAmbientTransaction;
 
-    internal class EnlistmentNotification : IEnlistmentNotification
+    internal class EnlistmentNotification(NonDurableStorageTransaction transaction) : IEnlistmentNotification
     {
-        public TaskCompletionSource TransactionCompletionSource { get; } = new TaskCompletionSource();
-
-        public EnlistmentNotification(NonDurableStorageTransaction transaction) =>
-            this.transaction = transaction;
+        public TaskCompletionSource TransactionCompletionSource { get; } = new();
 
         public void Prepare(PreparingEnlistment preparingEnlistment)
         {
@@ -156,7 +157,5 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         }
 
         public void InDoubt(Enlistment enlistment) => enlistment.Done();
-
-        readonly NonDurableStorageTransaction transaction;
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -10,8 +10,12 @@ using Outbox;
 using Persistence;
 using Transport;
 
-class NonDurableSynchronizedStorageSession : ICompletableSynchronizedStorageSession
+class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : ICompletableSynchronizedStorageSession, INonDurableStorageSession
 {
+    public NonDurableSynchronizedStorageSession() : this(NonDurableStorageRuntime.SharedStorage)
+    {
+    }
+
     public NonDurableStorageTransaction? Transaction { get; private set; }
 
     public void Dispose()
@@ -21,7 +25,7 @@ class NonDurableSynchronizedStorageSession : ICompletableSynchronizedStorageSess
             // In the DTC path, the ambient transaction drives commit/rollback via
             // EnlistmentNotification — do not dispose activities here; they will be
             // disposed when the ambient transaction commits/rolls back. When we own
-            // the transaction and it wasn't committed, dispose tracked activities to
+            // the transaction, and it wasn't committed, dispose tracked activities to
             // avoid leaks (e.g. handler failure in the non-DTC path).
             if (ownsTransaction && !enlistedInAmbientTransaction)
             {
@@ -109,6 +113,10 @@ class NonDurableSynchronizedStorageSession : ICompletableSynchronizedStorageSess
         ArgumentNullException.ThrowIfNull(Transaction);
         Transaction.Enlist(state, apply, rollback, activity);
     }
+
+    public TSagaData? GetSagaData<TSagaData>(IReadOnlyContextBag context, Func<TSagaData, bool> predicate, CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData =>
+        NonDurableSagaDataProjection.GetSagaData(storage, context, predicate, cancellationToken);
 
     bool ownsTransaction;
     bool enlistedInAmbientTransaction;

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSessionExtensions.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSessionExtensions.cs
@@ -7,7 +7,7 @@ using Persistence.NonDurable;
 /// <summary>
 /// NonDurable persistence specific extension methods for <see cref="ISynchronizedStorageSession" />.
 /// </summary>
-public static class SynchronizedStorageSessionExtensions
+public static class NonDurableSynchronizedStorageSessionExtensions
 {
     /// <summary>
     /// Retrieves the NonDurable persistence session from the synchronized storage session.

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableTransactionalStorageFeature.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableTransactionalStorageFeature.cs
@@ -10,5 +10,10 @@ sealed class NonDurableTransactionalStorageFeature : Feature
     public NonDurableTransactionalStorageFeature() => DependsOn<SynchronizedStorage>();
 
     protected override void Setup(FeatureConfigurationContext context)
-        => context.Services.AddScoped<ICompletableSynchronizedStorageSession, NonDurableSynchronizedStorageSession>();
+    {
+        NonDurablePersistenceOptions persistenceOptions = context.Settings.Get<NonDurablePersistenceOptions>();
+        NonDurableStorageRuntime.Configure(context.Services, persistenceOptions);
+
+        context.Services.AddScoped<ICompletableSynchronizedStorageSession>(sp => new NonDurableSynchronizedStorageSession(sp.GetRequiredService<NonDurableStorage>()));
+    }
 }

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/SynchronizedStorageSessionExtensions.cs
@@ -1,0 +1,26 @@
+namespace NServiceBus;
+
+using System;
+using Persistence;
+using Persistence.NonDurable;
+
+/// <summary>
+/// NonDurable persistence specific extension methods for <see cref="ISynchronizedStorageSession" />.
+/// </summary>
+public static class SynchronizedStorageSessionExtensions
+{
+    /// <summary>
+    /// Retrieves the NonDurable persistence session from the synchronized storage session.
+    /// </summary>
+    public static INonDurableStorageSession NonDurablePersistenceSession(this ISynchronizedStorageSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        if (session is INonDurableStorageSession nonDurableSession)
+        {
+            return nonDurableSession;
+        }
+
+        throw new Exception($"Cannot access the synchronized storage session. Ensure that 'EndpointConfiguration.UsePersistence<{nameof(NonDurablePersistence)}>()' has been called.");
+    }
+}

--- a/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
@@ -1,0 +1,41 @@
+namespace NServiceBus.Testing;
+
+using System;
+using System.Threading;
+using Extensibility;
+using Persistence;
+using Persistence.NonDurable;
+using Persistence.NonDurable.SagaPersister;
+
+/// <summary>
+/// A fake implementation of the NonDurable synchronized storage session for testing purposes.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using the specified storage instance.
+/// </remarks>
+public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage storage) : ISynchronizedStorageSession, INonDurableStorageSession
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using a new <see cref="NonDurableStorage" /> instance.
+    /// </summary>
+    public TestableNonDurableSynchronizedStorageSession() : this(new NonDurableStorage())
+    {
+    }
+
+    /// <summary>
+    /// Adds saga data to the test session storage.
+    /// </summary>
+    public void AddSaga<TSagaData>(TSagaData sagaData)
+        where TSagaData : class, IContainSagaData
+    {
+        ArgumentNullException.ThrowIfNull(sagaData);
+
+        var noCorrelationId = new CorrelationId(typeof(object), string.Empty, new object());
+        storage.Sagas[sagaData.Id] = new SagaEntry(sagaData, noCorrelationId, version: 1, new NonDurableSagaOptions().JsonSerializerOptions);
+    }
+
+    /// <inheritdoc />
+    public TSagaData? GetSagaData<TSagaData>(IReadOnlyContextBag context, Func<TSagaData, bool> predicate, CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData =>
+        NonDurableSagaDataProjection.GetSagaData(storage, context, predicate, cancellationToken);
+}

--- a/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
@@ -11,27 +11,40 @@ using Persistence.NonDurable.SagaPersister;
 /// A fake implementation of the NonDurable synchronized storage session for testing purposes.
 /// </summary>
 /// <remarks>
-/// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using the specified storage instance.
+/// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using the specified storage instance and saga options.
 /// </remarks>
-public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage storage) : ISynchronizedStorageSession, INonDurableStorageSession
+public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage storage, NonDurableSagaOptions sagaOptions) : ISynchronizedStorageSession, INonDurableStorageSession
 {
     /// <summary>
-    /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using a new <see cref="NonDurableStorage" /> instance.
+    /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using a new <see cref="NonDurableStorage" /> instance and default saga options.
     /// </summary>
-    public TestableNonDurableSynchronizedStorageSession() : this(new NonDurableStorage())
+    public TestableNonDurableSynchronizedStorageSession() : this(new NonDurableStorage(), new NonDurableSagaOptions())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using a new <see cref="NonDurableStorage" /> instance and the specified saga options.
+    /// </summary>
+    public TestableNonDurableSynchronizedStorageSession(NonDurableSagaOptions sagaOptions) : this(new NonDurableStorage(), sagaOptions)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using the specified storage instance and default saga options.
+    /// </summary>
+    public TestableNonDurableSynchronizedStorageSession(NonDurableStorage storage) : this(storage, new NonDurableSagaOptions())
     {
     }
 
     /// <summary>
     /// Adds saga data to the test session storage.
     /// </summary>
-    public void AddSaga<TSagaData>(TSagaData sagaData)
-        where TSagaData : class, IContainSagaData
+    public void AddSaga(IContainSagaData sagaData)
     {
         ArgumentNullException.ThrowIfNull(sagaData);
 
         var noCorrelationId = new CorrelationId(typeof(object), string.Empty, new object());
-        storage.Sagas[sagaData.Id] = new SagaEntry(sagaData, noCorrelationId, version: 1, new NonDurableSagaOptions().JsonSerializerOptions);
+        storage.Sagas[sagaData.Id] = new SagaEntry(sagaData, noCorrelationId, version: 1, sagaOptions.JsonSerializerOptions);
     }
 
     /// <inheritdoc />
@@ -43,4 +56,7 @@ public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage stor
     public TSagaData? GetSagaData<TSagaData, TState>(IReadOnlyContextBag context, TState state, Func<TSagaData, TState, bool> predicate, CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
         NonDurableSagaDataProjection.GetSagaData(storage, context, state, predicate, cancellationToken);
+
+    readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    readonly NonDurableSagaOptions sagaOptions = sagaOptions ?? throw new ArgumentNullException(nameof(sagaOptions));
 }

--- a/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
@@ -38,4 +38,9 @@ public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage stor
     public TSagaData? GetSagaData<TSagaData>(IReadOnlyContextBag context, Func<TSagaData, bool> predicate, CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
         NonDurableSagaDataProjection.GetSagaData(storage, context, predicate, cancellationToken);
+
+    /// <inheritdoc />
+    public TSagaData? GetSagaData<TSagaData, TState>(IReadOnlyContextBag context, TState state, Func<TSagaData, TState, bool> predicate, CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData =>
+        NonDurableSagaDataProjection.GetSagaData(storage, context, state, predicate, cancellationToken);
 }


### PR DESCRIPTION
This adds a small NonDurable-specific synchronized storage session API that custom saga finders can use to query saga data without maintaining their own side index.

The main use case is a finder that needs to correlate on a value that is not the configured saga correlation property. Previously, the acceptance test had to keep a separate `ServerTaskId -> saga id` dictionary and then call the saga persister by id. That still works and the test remains in place, but this PR adds the more direct path as well.

## What changed

- Added `INonDurableStorageSession` and `SynchronizedStorageSessionExtensions.NonDurablePersistenceSession()`.
- Added `GetSagaData<TSagaData>(...)` with a state-based overload so callers can avoid closure allocations when that matters.
- The query returns a copied saga data instance and captures the selected saga entry in the context so the existing optimistic concurrency checks still apply on update or complete.
- Documented that the query is evaluated against a moment-in-time snapshot while the underlying storage is enumerated.
- Added `TestableNonDurableSynchronizedStorageSession` for unit tests, including constructor-level `NonDurableSagaOptions` support for custom saga serialization.
- Added an acceptance test showing a custom finder resolving saga data by `ServerTaskId` through the synchronized storage session.
- Kept the existing custom-storage/index acceptance test and adjusted its comment so both scenarios are covered.
