### PR TITLE
Pessimistic concurrency for sagas

### DIFF
--- a/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/ApprovalFiles/APIApprovals.ApproveNonDurablePersistence.approved.txt
@@ -15,19 +15,27 @@ namespace NServiceBus
         public NServiceBus.NonDurableStorage? Storage { get; init; }
         public System.TimeProvider TimeProvider { get; init; }
     }
+    public enum NonDurableSagaConcurrencyMode
+    {
+        Optimistic = 0,
+        Pessimistic = 1,
+    }
     public sealed class NonDurableSagaOptions
     {
         public NonDurableSagaOptions() { }
+        public NServiceBus.NonDurableSagaConcurrencyMode ConcurrencyMode { get; init; }
         public System.Text.Json.JsonSerializerOptions JsonSerializerOptions { get; init; }
     }
     public class NonDurableStorage
     {
         public NonDurableStorage(NServiceBus.NonDurableStorageOptions? options = null) { }
+        public NServiceBus.NonDurableSagaConcurrencyMode SagaConcurrencyMode { get; }
         public System.TimeProvider TimeProvider { get; }
     }
     public sealed class NonDurableStorageOptions
     {
         public NonDurableStorageOptions() { }
+        public NServiceBus.NonDurableSagaConcurrencyMode SagaConcurrencyMode { get; init; }
         public System.TimeProvider? TimeProvider { get; init; }
     }
     public static class NonDurableSynchronizedStorageSessionExtensions

--- a/src/NServiceBus.Persistence.NonDurable.Tests/Design/When_registering_nondurable_storage.cs
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/Design/When_registering_nondurable_storage.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 public class When_registering_nondurable_storage
 {
     [Test]
-    public void Should_use_dependency_injection_then_explicit_configuration_then_shared_default()
+    public void Should_use_dependency_injection_then_explicit_configuration_then_shared_storage_for_matching_mode()
     {
         var serviceCollection = new ServiceCollection();
         var serviceProviderStorage = new NonDurableStorage();
@@ -32,6 +32,19 @@ public class When_registering_nondurable_storage
         NonDurableStorageRuntime.Configure(defaultServices, new NonDurablePersistenceOptions());
 
         using var defaultProvider = defaultServices.BuildServiceProvider();
-        Assert.That(defaultProvider.GetRequiredService<NonDurableStorage>(), Is.SameAs(NonDurableStorageRuntime.SharedStorage));
+        Assert.That(defaultProvider.GetRequiredService<NonDurableStorage>(), Is.SameAs(NonDurableStorageRuntime.SharedOptimisticStorage));
+
+        var pessimisticServices = new ServiceCollection();
+
+        NonDurableStorageRuntime.Configure(pessimisticServices, new NonDurablePersistenceOptions
+        {
+            Saga = new NonDurableSagaOptions
+            {
+                ConcurrencyMode = NonDurableSagaConcurrencyMode.Pessimistic
+            }
+        });
+
+        using var pessimisticProvider = pessimisticServices.BuildServiceProvider();
+        Assert.That(pessimisticProvider.GetRequiredService<NonDurableStorage>(), Is.SameAs(NonDurableStorageRuntime.SharedPessimisticStorage));
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable.Tests/When_multiple_workers_retrieve_same_saga.cs
+++ b/src/NServiceBus.Persistence.NonDurable.Tests/When_multiple_workers_retrieve_same_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Persistence.NonDurable.Tests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using NUnit.Framework;
@@ -206,6 +207,150 @@
                 Throws.InstanceOf<Exception>().And.Message
                     .StartsWith(
                         $"NonDurableSagaPersister concurrency violation: saga entity Id[{saga.Id}] was modified by another process."));
+        }
+
+        [Test]
+        public async Task Pessimistic_get_waits_for_current_holder_and_reads_latest_data()
+        {
+            var saga = new TestSagaData
+            {
+                Id = Guid.NewGuid(),
+                SomeId = "Original"
+            };
+
+            var (persister, options, storage) = CreatePessimisticPersister();
+            await SaveSaga(persister, storage, saga);
+
+            var firstSession = new NonDurableSynchronizedStorageSession(storage);
+            await firstSession.Open(new ContextBag());
+            var firstContext = new ContextBag();
+
+            var secondSession = new NonDurableSynchronizedStorageSession(storage);
+            await secondSession.Open(new ContextBag());
+            var secondContext = new ContextBag();
+
+            try
+            {
+                var firstSaga = await persister.Get<TestSagaData>(saga.Id, firstSession, firstContext);
+
+                var secondGetTask = Task.Run(async () =>
+                    await persister.Get<TestSagaData>(saga.Id, secondSession, secondContext));
+
+                Assert.That(await Task.WhenAny(secondGetTask, Task.Delay(200)), Is.Not.SameAs(secondGetTask));
+
+                firstSaga.SomeId = "Updated";
+                await persister.Update(firstSaga, firstSession, firstContext);
+                await firstSession.CompleteAsync();
+
+                var secondSaga = await secondGetTask;
+                Assert.That(secondSaga.SomeId, Is.EqualTo("Updated"));
+
+                await secondSession.CompleteAsync();
+            }
+            finally
+            {
+                firstSession.Dispose();
+                secondSession.Dispose();
+            }
+        }
+
+        [Test]
+        public async Task Pessimistic_get_detects_deadlock_when_two_sessions_wait_on_each_other()
+        {
+            var firstSaga = new TestSagaData
+            {
+                Id = Guid.NewGuid(),
+                SomeId = "First"
+            };
+            var secondSaga = new TestSagaData
+            {
+                Id = Guid.NewGuid(),
+                SomeId = "Second"
+            };
+
+            var (persister, options, storage) = CreatePessimisticPersister();
+            await SaveSaga(persister, storage, firstSaga);
+            await SaveSaga(persister, storage, secondSaga);
+
+            var firstSession = new NonDurableSynchronizedStorageSession(storage);
+            await firstSession.Open(new ContextBag());
+
+            var secondSession = new NonDurableSynchronizedStorageSession(storage);
+            await secondSession.Open(new ContextBag());
+
+            try
+            {
+                await persister.Get<TestSagaData>(firstSaga.Id, firstSession, new ContextBag());
+                await persister.Get<TestSagaData>(secondSaga.Id, secondSession, new ContextBag());
+
+                var firstWaitTask = Task.Run(async () =>
+                    await persister.Get<TestSagaData>(secondSaga.Id, firstSession, new ContextBag(), CancellationToken.None));
+
+                Assert.That(await Task.WhenAny(firstWaitTask, Task.Delay(200)), Is.Not.SameAs(firstWaitTask));
+
+                Assert.That(
+                    async () => await persister.Get<TestSagaData>(firstSaga.Id, secondSession, new ContextBag(), CancellationToken.None),
+                    Throws.InstanceOf<Exception>().And.Message.Contains("deadlock detected"));
+
+                secondSession.Dispose();
+                await firstWaitTask;
+            }
+            finally
+            {
+                firstSession.Dispose();
+                secondSession.Dispose();
+            }
+        }
+
+        [Test]
+        public void Shared_storage_rejects_conflicting_saga_concurrency_modes()
+        {
+            var storage = new NonDurableStorage(new NonDurableStorageOptions
+            {
+                SagaConcurrencyMode = NonDurableSagaConcurrencyMode.Pessimistic
+            });
+
+            _ = new NonDurableSagaPersister(storage, new NonDurableSagaOptions
+            {
+                ConcurrencyMode = NonDurableSagaConcurrencyMode.Pessimistic
+            });
+
+            Assert.That(
+                () => new NonDurableSagaPersister(storage, new NonDurableSagaOptions
+                {
+                    ConcurrencyMode = NonDurableSagaConcurrencyMode.Optimistic
+                }),
+                Throws.InstanceOf<InvalidOperationException>().And.Message.Contains("uses Pessimistic"));
+        }
+
+        static async Task SaveSaga(NonDurableSagaPersister persister, NonDurableStorage storage, TestSagaData saga)
+        {
+            var session = new NonDurableSynchronizedStorageSession(storage);
+            await session.Open(new ContextBag());
+
+            try
+            {
+                await persister.Save(saga, SagaMetadataHelper.GetMetadata<TestSaga>(saga), session, new ContextBag());
+                await session.CompleteAsync();
+            }
+            finally
+            {
+                session.Dispose();
+            }
+        }
+
+        static (NonDurableSagaPersister Persister, NonDurableSagaOptions Options, NonDurableStorage Storage) CreatePessimisticPersister()
+        {
+            var options = new NonDurableSagaOptions
+            {
+                ConcurrencyMode = NonDurableSagaConcurrencyMode.Pessimistic
+            };
+            var storage = new NonDurableStorage(new NonDurableStorageOptions
+            {
+                SagaConcurrencyMode = NonDurableSagaConcurrencyMode.Pessimistic
+            });
+            var persister = new NonDurableSagaPersister(storage, options);
+            return (persister, options, storage);
         }
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable/CompletionCallbacks.cs
+++ b/src/NServiceBus.Persistence.NonDurable/CompletionCallbacks.cs
@@ -1,0 +1,40 @@
+namespace NServiceBus.Persistence.NonDurable;
+
+using System;
+using System.Collections.Generic;
+
+sealed class CompletionCallbacks
+{
+    public void Add(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (callbacksExecuted)
+        {
+            callback();
+            return;
+        }
+
+        callbacks.Add(callback);
+    }
+
+    public void Run()
+    {
+        if (callbacksExecuted)
+        {
+            return;
+        }
+
+        callbacksExecuted = true;
+
+        foreach (var callback in callbacks)
+        {
+            callback();
+        }
+
+        callbacks.Clear();
+    }
+
+    readonly List<Action> callbacks = [];
+    bool callbacksExecuted;
+}

--- a/src/NServiceBus.Persistence.NonDurable/NonDurableSagaConcurrencyMode.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableSagaConcurrencyMode.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus;
+
+/// <summary>
+/// Controls how NonDurable saga persistence coordinates concurrent access to saga data.
+/// </summary>
+public enum NonDurableSagaConcurrencyMode
+{
+    /// <summary>
+    /// Loads saga data without taking a lock and detects conflicts when changes are committed.
+    /// </summary>
+    Optimistic = 0,
+
+    /// <summary>
+    /// Takes an exclusive per-saga lock when existing saga data is loaded and holds it until the storage session completes.
+    /// Conflicts are still validated when changes are committed.
+    /// </summary>
+    Pessimistic = 1
+}

--- a/src/NServiceBus.Persistence.NonDurable/NonDurableSagaOptions.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableSagaOptions.cs
@@ -8,6 +8,11 @@ using System.Text.Json;
 public sealed class NonDurableSagaOptions
 {
     /// <summary>
+    /// Gets or sets how saga persistence coordinates concurrent access to saga data.
+    /// </summary>
+    public NonDurableSagaConcurrencyMode ConcurrencyMode { get; init; } = NonDurableSagaConcurrencyMode.Optimistic;
+
+    /// <summary>
     /// Gets or sets the <see cref="JsonSerializerOptions"/> used to persist saga data.
     /// </summary>
     /// <remarks>

--- a/src/NServiceBus.Persistence.NonDurable/NonDurableStorage.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableStorage.cs
@@ -15,17 +15,28 @@ public class NonDurableStorage
     /// <summary>
     /// Initializes a new instance of <see cref="NonDurableStorage"/> with the specified options.
     /// </summary>
-    /// <param name="options">The options to configure the non-durable persistence storage. When <c>null</c>, <see cref="TimeProvider.System"/> is used.</param>
-    public NonDurableStorage(NonDurableStorageOptions? options = null) => TimeProvider = options?.TimeProvider ?? TimeProvider.System;
+    /// <param name="options">The options to configure the non-durable persistence storage. When <c>null</c>, <see cref="TimeProvider.System"/> and optimistic saga concurrency are used.</param>
+    public NonDurableStorage(NonDurableStorageOptions? options = null)
+    {
+        TimeProvider = options?.TimeProvider ?? TimeProvider.System;
+        SagaConcurrencyMode = options?.SagaConcurrencyMode ?? NonDurableSagaConcurrencyMode.Optimistic;
+    }
 
     /// <summary>
     /// The <see cref="TimeProvider"/> used for outbox entry expiry and timestamps.
     /// </summary>
     public TimeProvider TimeProvider { get; }
 
+    /// <summary>
+    /// The saga concurrency mode used by this storage instance.
+    /// </summary>
+    public NonDurableSagaConcurrencyMode SagaConcurrencyMode { get; }
+
     internal ConcurrentDictionary<Guid, SagaEntry> Sagas { get; } = new();
 
     internal ConcurrentDictionary<CorrelationId, Guid> SagaCorrelationIds { get; } = new();
+
+    internal SagaLockManager SagaLocks { get; } = new();
 
     internal ConcurrentDictionary<string, StoredOutboxMessage> OutboxMessages { get; } = new(StringComparer.Ordinal);
 

--- a/src/NServiceBus.Persistence.NonDurable/NonDurableStorageOptions.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableStorageOptions.cs
@@ -8,6 +8,11 @@ using System;
 public sealed class NonDurableStorageOptions
 {
     /// <summary>
+    /// Gets or sets how saga persistence coordinates concurrent access for this storage instance.
+    /// </summary>
+    public NonDurableSagaConcurrencyMode SagaConcurrencyMode { get; init; } = NonDurableSagaConcurrencyMode.Optimistic;
+
+    /// <summary>
     /// Gets or sets the <see cref="TimeProvider"/> used for outbox entry expiry and timestamps.
     /// When set to <c>null</c>, <see cref="TimeProvider.System"/> is used.
     /// </summary>

--- a/src/NServiceBus.Persistence.NonDurable/NonDurableStorageRuntime.cs
+++ b/src/NServiceBus.Persistence.NonDurable/NonDurableStorageRuntime.cs
@@ -6,7 +6,11 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 static class NonDurableStorageRuntime
 {
-    public static NonDurableStorage SharedStorage { get; } = new();
+    public static NonDurableStorage SharedOptimisticStorage { get; } = new();
+    public static NonDurableStorage SharedPessimisticStorage { get; } = new(new NonDurableStorageOptions
+    {
+        SagaConcurrencyMode = NonDurableSagaConcurrencyMode.Pessimistic
+    });
 
     public static void Configure(IServiceCollection services, NonDurablePersistenceOptions persistenceOptions)
     {
@@ -14,9 +18,21 @@ static class NonDurableStorageRuntime
 
         var storage = persistenceOptions.Storage
             ?? (persistenceOptions.TimeProvider != TimeProvider.System
-                ? new NonDurableStorage(new NonDurableStorageOptions { TimeProvider = persistenceOptions.TimeProvider })
+                ? new NonDurableStorage(new NonDurableStorageOptions
+                {
+                    TimeProvider = persistenceOptions.TimeProvider,
+                    SagaConcurrencyMode = persistenceOptions.Saga.ConcurrencyMode
+                })
                 : null)
-            ?? SharedStorage;
+            ?? GetSharedStorage(persistenceOptions.Saga.ConcurrencyMode);
         services.TryAddSingleton(storage);
     }
+
+    static NonDurableStorage GetSharedStorage(NonDurableSagaConcurrencyMode concurrencyMode) =>
+        concurrencyMode switch
+        {
+            NonDurableSagaConcurrencyMode.Optimistic => SharedOptimisticStorage,
+            NonDurableSagaConcurrencyMode.Pessimistic => SharedPessimisticStorage,
+            _ => throw new ArgumentOutOfRangeException(nameof(concurrencyMode), concurrencyMode, "Unsupported saga concurrency mode.")
+        };
 }

--- a/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxTransaction.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxTransaction.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Persistence.NonDurable;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,8 +21,29 @@ class NonDurableOutboxTransaction : IOutboxTransaction
 
     public Task Commit(CancellationToken cancellationToken = default)
     {
-        Transaction?.Commit();
+        try
+        {
+            Transaction?.Commit();
+        }
+        finally
+        {
+            RunCompletionCallbacks();
+        }
+
         return Task.CompletedTask;
+    }
+
+    internal void OnCompleted(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        if (completionCallbacksExecuted)
+        {
+            callback();
+            return;
+        }
+
+        completionCallbacks.Add(callback);
     }
 
     public void Dispose()
@@ -29,6 +51,7 @@ class NonDurableOutboxTransaction : IOutboxTransaction
         if (Transaction is { } tx)
         {
             tx.DisposeTrackedActivities();
+            RunCompletionCallbacks();
             Transaction = null;
         }
     }
@@ -38,4 +61,24 @@ class NonDurableOutboxTransaction : IOutboxTransaction
         Dispose();
         return default;
     }
+
+    void RunCompletionCallbacks()
+    {
+        if (completionCallbacksExecuted)
+        {
+            return;
+        }
+
+        completionCallbacksExecuted = true;
+
+        foreach (var callback in completionCallbacks)
+        {
+            callback();
+        }
+
+        completionCallbacks.Clear();
+    }
+
+    readonly List<Action> completionCallbacks = [];
+    bool completionCallbacksExecuted;
 }

--- a/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxTransaction.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Outbox/NonDurableOutboxTransaction.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Persistence.NonDurable;
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -27,7 +26,7 @@ class NonDurableOutboxTransaction : IOutboxTransaction
         }
         finally
         {
-            RunCompletionCallbacks();
+            completionCallbacks.Run();
         }
 
         return Task.CompletedTask;
@@ -35,14 +34,6 @@ class NonDurableOutboxTransaction : IOutboxTransaction
 
     internal void OnCompleted(Action callback)
     {
-        ArgumentNullException.ThrowIfNull(callback);
-
-        if (completionCallbacksExecuted)
-        {
-            callback();
-            return;
-        }
-
         completionCallbacks.Add(callback);
     }
 
@@ -51,7 +42,7 @@ class NonDurableOutboxTransaction : IOutboxTransaction
         if (Transaction is { } tx)
         {
             tx.DisposeTrackedActivities();
-            RunCompletionCallbacks();
+            completionCallbacks.Run();
             Transaction = null;
         }
     }
@@ -62,23 +53,5 @@ class NonDurableOutboxTransaction : IOutboxTransaction
         return default;
     }
 
-    void RunCompletionCallbacks()
-    {
-        if (completionCallbacksExecuted)
-        {
-            return;
-        }
-
-        completionCallbacksExecuted = true;
-
-        foreach (var callback in completionCallbacks)
-        {
-            callback();
-        }
-
-        completionCallbacks.Clear();
-    }
-
-    readonly List<Action> completionCallbacks = [];
-    bool completionCallbacksExecuted;
+    readonly CompletionCallbacks completionCallbacks = new();
 }

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/INonDurableSagaLockingSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/INonDurableSagaLockingSession.cs
@@ -1,0 +1,13 @@
+namespace NServiceBus.Persistence.NonDurable.SagaPersister;
+
+using System;
+using System.Threading;
+
+interface INonDurableSagaLockingSession
+{
+    bool UsesPessimisticSagaConcurrency { get; }
+
+    bool TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken = default);
+
+    void ReleaseSagaLock(Guid sagaId);
+}

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
@@ -9,14 +9,14 @@ static class NonDurableSagaDataProjection
 {
     public static TSagaData? GetSagaData<TSagaData>(
         NonDurableStorage storage,
-        INonDurableSagaLockingSession session,
+        INonDurableSagaLockingSession lockingSession,
         IReadOnlyContextBag context,
         Func<TSagaData, bool> predicate,
         CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
         GetSagaData<TSagaData, Func<TSagaData, bool>>(
             storage,
-            session,
+            lockingSession,
             context,
             predicate,
             static (sagaData, predicate) => predicate(sagaData),
@@ -24,7 +24,7 @@ static class NonDurableSagaDataProjection
 
     public static TSagaData? GetSagaData<TSagaData, TState>(
         NonDurableStorage storage,
-        INonDurableSagaLockingSession session,
+        INonDurableSagaLockingSession lockingSession,
         IReadOnlyContextBag context,
         TState state,
         Func<TSagaData, TState, bool> predicate,
@@ -32,7 +32,7 @@ static class NonDurableSagaDataProjection
         where TSagaData : class, IContainSagaData
     {
         ArgumentNullException.ThrowIfNull(storage);
-        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(lockingSession);
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(predicate);
 
@@ -56,10 +56,10 @@ static class NonDurableSagaDataProjection
                 continue;
             }
 
-            var lockAcquired = session.TryAcquireSagaLock(sagaId, cancellationToken);
+            var lockAcquired = lockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
             try
             {
-                if (!session.UsesPessimisticSagaConcurrency)
+                if (!lockingSession.UsesPessimisticSagaConcurrency)
                 {
                     NonDurableSagaPersister.SetEntry(contextBag, sagaId, entry);
                     return sagaData;
@@ -69,18 +69,19 @@ static class NonDurableSagaDataProjection
                 {
                     if (lockAcquired)
                     {
-                        session.ReleaseSagaLock(sagaId);
+                        lockingSession.ReleaseSagaLock(sagaId);
                     }
 
                     continue;
                 }
 
+                // First copy of the data may already be stale since the lock was acquired
                 var lockedSagaData = (TSagaData)liveEntry.GetSagaCopy();
                 if (!predicate(lockedSagaData, state))
                 {
                     if (lockAcquired)
                     {
-                        session.ReleaseSagaLock(sagaId);
+                        lockingSession.ReleaseSagaLock(sagaId);
                     }
 
                     continue;
@@ -93,7 +94,7 @@ static class NonDurableSagaDataProjection
             {
                 if (lockAcquired)
                 {
-                    session.ReleaseSagaLock(sagaId);
+                    lockingSession.ReleaseSagaLock(sagaId);
                 }
 
                 throw;

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
@@ -56,48 +56,33 @@ static class NonDurableSagaDataProjection
                 continue;
             }
 
-            var lockAcquired = lockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
-            try
+            if (!lockingSession.UsesPessimisticSagaConcurrency)
             {
-                if (!lockingSession.UsesPessimisticSagaConcurrency)
-                {
-                    NonDurableSagaPersister.SetEntry(contextBag, sagaId, entry);
-                    return sagaData;
-                }
-
-                if (!storage.Sagas.TryGetValue(sagaId, out var liveEntry) || liveEntry.SagaDataType != typeof(TSagaData))
-                {
-                    if (lockAcquired)
-                    {
-                        lockingSession.ReleaseSagaLock(sagaId);
-                    }
-
-                    continue;
-                }
-
-                // First copy of the data may already be stale since the lock was acquired
-                var lockedSagaData = (TSagaData)liveEntry.GetSagaCopy();
-                if (!predicate(lockedSagaData, state))
-                {
-                    if (lockAcquired)
-                    {
-                        lockingSession.ReleaseSagaLock(sagaId);
-                    }
-
-                    continue;
-                }
-
-                NonDurableSagaPersister.SetEntry(contextBag, sagaId, liveEntry);
-                return lockedSagaData;
+                NonDurableSagaPersister.SetEntry(contextBag, sagaId, entry);
+                return sagaData;
             }
-            catch
-            {
-                if (lockAcquired)
-                {
-                    lockingSession.ReleaseSagaLock(sagaId);
-                }
 
-                throw;
+            var lockedSagaData = SagaReadLocking.ReadCurrent<TSagaData>(
+                storage.Sagas,
+                lockingSession,
+                sagaId,
+                liveEntry =>
+                {
+                    if (liveEntry.SagaDataType != typeof(TSagaData))
+                    {
+                        return null;
+                    }
+
+                    // First copy of the data may already be stale since the lock was acquired.
+                    var currentSagaData = (TSagaData)liveEntry.GetSagaCopy();
+                    return predicate(currentSagaData, state) ? currentSagaData : null;
+                },
+                (capturedSagaId, capturedEntry) => NonDurableSagaPersister.SetEntry(contextBag, capturedSagaId, capturedEntry),
+                cancellationToken);
+
+            if (lockedSagaData is not null)
+            {
+                return lockedSagaData;
             }
         }
 

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDataProjection.cs
@@ -3,17 +3,20 @@ namespace NServiceBus.Persistence.NonDurable;
 using System;
 using System.Threading;
 using Extensibility;
+using SagaPersister;
 
 static class NonDurableSagaDataProjection
 {
     public static TSagaData? GetSagaData<TSagaData>(
         NonDurableStorage storage,
+        INonDurableSagaLockingSession session,
         IReadOnlyContextBag context,
         Func<TSagaData, bool> predicate,
         CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
         GetSagaData<TSagaData, Func<TSagaData, bool>>(
             storage,
+            session,
             context,
             predicate,
             static (sagaData, predicate) => predicate(sagaData),
@@ -21,6 +24,7 @@ static class NonDurableSagaDataProjection
 
     public static TSagaData? GetSagaData<TSagaData, TState>(
         NonDurableStorage storage,
+        INonDurableSagaLockingSession session,
         IReadOnlyContextBag context,
         TState state,
         Func<TSagaData, TState, bool> predicate,
@@ -28,6 +32,7 @@ static class NonDurableSagaDataProjection
         where TSagaData : class, IContainSagaData
     {
         ArgumentNullException.ThrowIfNull(storage);
+        ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(predicate);
 
@@ -51,8 +56,48 @@ static class NonDurableSagaDataProjection
                 continue;
             }
 
-            NonDurableSagaPersister.SetEntry(contextBag, sagaId, entry);
-            return sagaData;
+            var lockAcquired = session.TryAcquireSagaLock(sagaId, cancellationToken);
+            try
+            {
+                if (!session.UsesPessimisticSagaConcurrency)
+                {
+                    NonDurableSagaPersister.SetEntry(contextBag, sagaId, entry);
+                    return sagaData;
+                }
+
+                if (!storage.Sagas.TryGetValue(sagaId, out var liveEntry) || liveEntry.SagaDataType != typeof(TSagaData))
+                {
+                    if (lockAcquired)
+                    {
+                        session.ReleaseSagaLock(sagaId);
+                    }
+
+                    continue;
+                }
+
+                var lockedSagaData = (TSagaData)liveEntry.GetSagaCopy();
+                if (!predicate(lockedSagaData, state))
+                {
+                    if (lockAcquired)
+                    {
+                        session.ReleaseSagaLock(sagaId);
+                    }
+
+                    continue;
+                }
+
+                NonDurableSagaPersister.SetEntry(contextBag, sagaId, liveEntry);
+                return lockedSagaData;
+            }
+            catch
+            {
+                if (lockAcquired)
+                {
+                    session.ReleaseSagaLock(sagaId);
+                }
+
+                throw;
+            }
         }
 
         return null;

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDeadlockException.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDeadlockException.cs
@@ -1,0 +1,8 @@
+namespace NServiceBus.Persistence.NonDurable.SagaPersister;
+
+using System;
+
+sealed class NonDurableSagaDeadlockException(Guid sagaId)
+    : Exception($"NonDurableSagaPersister deadlock detected while acquiring saga entity Id[{sagaId}].")
+{
+}

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDeadlockException.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaDeadlockException.cs
@@ -3,6 +3,6 @@ namespace NServiceBus.Persistence.NonDurable.SagaPersister;
 using System;
 
 sealed class NonDurableSagaDeadlockException(Guid sagaId)
-    : Exception($"NonDurableSagaPersister deadlock detected while acquiring saga entity Id[{sagaId}].")
+    : Exception($"NonDurableSagaPersister deadlock detected while acquiring saga entity Id {sagaId}.")
 {
 }

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -90,34 +90,19 @@ class NonDurableSagaPersister : ISagaPersister
         where TSagaData : class, IContainSagaData
     {
         using var activity = NonDurablePersistenceTracing.StartSagaGetById(sagaId);
-        var lockingSession = (INonDurableSagaLockingSession)session;
-        var lockAcquired = lockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
+        var sagaData = SagaReadLocking.ReadCurrent<TSagaData>(
+            sagas,
+            (INonDurableSagaLockingSession)session,
+            sagaId,
+            static entry => (TSagaData)entry.GetSagaCopy(),
+            (capturedSagaId, capturedEntry) => SetEntry(context, capturedSagaId, capturedEntry),
+            cancellationToken);
 
-        try
+        if (sagaData is not null)
         {
-            if (sagas.TryGetValue(sagaId, out var value))
-            {
-                SetEntry(context, sagaId, value);
-
-                var data = value.GetSagaCopy();
-                NonDurablePersistenceTracing.AddHitEvent(activity);
-                NonDurablePersistenceTracing.MarkSuccess(activity);
-                return Task.FromResult((TSagaData)data);
-            }
-        }
-        catch
-        {
-            if (lockAcquired)
-            {
-                lockingSession.ReleaseSagaLock(sagaId);
-            }
-
-            throw;
-        }
-
-        if (lockAcquired)
-        {
-            lockingSession.ReleaseSagaLock(sagaId);
+            NonDurablePersistenceTracing.AddHitEvent(activity);
+            NonDurablePersistenceTracing.MarkSuccess(activity);
+            return Task.FromResult(sagaData);
         }
 
         NonDurablePersistenceTracing.AddMissEvent(activity);
@@ -130,36 +115,24 @@ class NonDurableSagaPersister : ISagaPersister
     {
         using var activity = NonDurablePersistenceTracing.StartSagaGetByProperty(typeof(TSagaData), propertyName, propertyValue);
         var key = new CorrelationId(typeof(TSagaData), propertyName, propertyValue);
-        var lockingSession = (INonDurableSagaLockingSession)session;
 
         if (byCorrelationId.TryGetValue(key, out var id))
         {
-            var lockAcquired = lockingSession.TryAcquireSagaLock(id, cancellationToken);
+            var sagaData = SagaReadLocking.ReadCurrent<TSagaData>(
+                sagas,
+                (INonDurableSagaLockingSession)session,
+                id,
+                entry => entry.CorrelationId.Equals(key)
+                    ? (TSagaData)entry.GetSagaCopy()
+                    : null,
+                (capturedSagaId, capturedEntry) => SetEntry(context, capturedSagaId, capturedEntry),
+                cancellationToken);
 
-            try
+            if (sagaData is not null)
             {
-                if (sagas.TryGetValue(id, out var value) && value.CorrelationId.Equals(key))
-                {
-                    SetEntry(context, id, value);
-                    var data = value.GetSagaCopy();
-                    NonDurablePersistenceTracing.AddHitEvent(activity);
-                    NonDurablePersistenceTracing.MarkSuccess(activity);
-                    return Task.FromResult((TSagaData)data);
-                }
-            }
-            catch
-            {
-                if (lockAcquired)
-                {
-                    lockingSession.ReleaseSagaLock(id);
-                }
-
-                throw;
-            }
-
-            if (lockAcquired)
-            {
-                lockingSession.ReleaseSagaLock(id);
+                NonDurablePersistenceTracing.AddHitEvent(activity);
+                NonDurablePersistenceTracing.MarkSuccess(activity);
+                return Task.FromResult(sagaData);
             }
         }
 

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs
@@ -15,6 +15,11 @@ class NonDurableSagaPersister : ISagaPersister
     public NonDurableSagaPersister(NonDurableStorage storage, NonDurableSagaOptions options)
     {
         this.options = options;
+        if (storage.SagaConcurrencyMode != options.ConcurrencyMode)
+        {
+            throw new InvalidOperationException($"The shared {nameof(NonDurableStorage)} instance uses {storage.SagaConcurrencyMode} saga concurrency and cannot be used with persister mode {options.ConcurrencyMode}.");
+        }
+
         sagas = storage.Sagas;
         byCorrelationId = storage.SagaCorrelationIds;
     }
@@ -85,14 +90,34 @@ class NonDurableSagaPersister : ISagaPersister
         where TSagaData : class, IContainSagaData
     {
         using var activity = NonDurablePersistenceTracing.StartSagaGetById(sagaId);
-        if (sagas.TryGetValue(sagaId, out var value))
-        {
-            SetEntry(context, sagaId, value);
+        var lockingSession = (INonDurableSagaLockingSession)session;
+        var lockAcquired = lockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
 
-            var data = value.GetSagaCopy();
-            NonDurablePersistenceTracing.AddHitEvent(activity);
-            NonDurablePersistenceTracing.MarkSuccess(activity);
-            return Task.FromResult((TSagaData)data);
+        try
+        {
+            if (sagas.TryGetValue(sagaId, out var value))
+            {
+                SetEntry(context, sagaId, value);
+
+                var data = value.GetSagaCopy();
+                NonDurablePersistenceTracing.AddHitEvent(activity);
+                NonDurablePersistenceTracing.MarkSuccess(activity);
+                return Task.FromResult((TSagaData)data);
+            }
+        }
+        catch
+        {
+            if (lockAcquired)
+            {
+                lockingSession.ReleaseSagaLock(sagaId);
+            }
+
+            throw;
+        }
+
+        if (lockAcquired)
+        {
+            lockingSession.ReleaseSagaLock(sagaId);
         }
 
         NonDurablePersistenceTracing.AddMissEvent(activity);
@@ -105,16 +130,36 @@ class NonDurableSagaPersister : ISagaPersister
     {
         using var activity = NonDurablePersistenceTracing.StartSagaGetByProperty(typeof(TSagaData), propertyName, propertyValue);
         var key = new CorrelationId(typeof(TSagaData), propertyName, propertyValue);
+        var lockingSession = (INonDurableSagaLockingSession)session;
 
         if (byCorrelationId.TryGetValue(key, out var id))
         {
-            if (sagas.TryGetValue(id, out var value))
+            var lockAcquired = lockingSession.TryAcquireSagaLock(id, cancellationToken);
+
+            try
             {
-                SetEntry(context, id, value);
-                var data = value.GetSagaCopy();
-                NonDurablePersistenceTracing.AddHitEvent(activity);
-                NonDurablePersistenceTracing.MarkSuccess(activity);
-                return Task.FromResult((TSagaData)data);
+                if (sagas.TryGetValue(id, out var value) && value.CorrelationId.Equals(key))
+                {
+                    SetEntry(context, id, value);
+                    var data = value.GetSagaCopy();
+                    NonDurablePersistenceTracing.AddHitEvent(activity);
+                    NonDurablePersistenceTracing.MarkSuccess(activity);
+                    return Task.FromResult((TSagaData)data);
+                }
+            }
+            catch
+            {
+                if (lockAcquired)
+                {
+                    lockingSession.ReleaseSagaLock(id);
+                }
+
+                throw;
+            }
+
+            if (lockAcquired)
+            {
+                lockingSession.ReleaseSagaLock(id);
             }
         }
 

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaLockManager.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaLockManager.cs
@@ -22,6 +22,8 @@ sealed class SagaLockManager
 
             if (lockState.OwnerId is null)
             {
+                // Non-blocking consistency check, not a real wait. If this fails, our ownership bookkeeping
+                // and the semaphore state have diverged, so throw
                 if (!lockState.Semaphore.Wait(0, CancellationToken.None))
                 {
                     throw new InvalidOperationException($"Failed to acquire the free saga lock for Id[{sagaId}].");
@@ -154,6 +156,7 @@ sealed class SagaLockManager
     }
 
     readonly object syncRoot = new();
+    // Regular dictionaries simpler / cheaper as they're only accessed under a lock on syncRoot
     readonly Dictionary<Guid, SagaLockState> lockStates = [];
     readonly Dictionary<Guid, Guid> waitingOwners = [];
 

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaLockManager.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaLockManager.cs
@@ -1,0 +1,185 @@
+namespace NServiceBus.Persistence.NonDurable.SagaPersister;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+sealed class SagaLockManager
+{
+    public IDisposable Acquire(Guid ownerId, Guid sagaId, CancellationToken cancellationToken = default)
+    {
+        SagaLockState lockState;
+
+        lock (syncRoot)
+        {
+            lockState = GetOrAddLockState(sagaId);
+
+            if (lockState.OwnerId == ownerId)
+            {
+                lockState.ReentrancyCount++;
+                return new SagaLockLease(this, ownerId, sagaId);
+            }
+
+            if (lockState.OwnerId is null)
+            {
+                if (!lockState.Semaphore.Wait(0, CancellationToken.None))
+                {
+                    throw new InvalidOperationException($"Failed to acquire the free saga lock for Id[{sagaId}].");
+                }
+
+                lockState.OwnerId = ownerId;
+                lockState.ReentrancyCount = 1;
+                return new SagaLockLease(this, ownerId, sagaId);
+            }
+
+            lockState.WaiterCount++;
+            waitingOwners[ownerId] = lockState.OwnerId.Value;
+
+            if (CreatesCycle(ownerId, lockState.OwnerId.Value))
+            {
+                waitingOwners.Remove(ownerId);
+                lockState.WaiterCount--;
+                RemoveUnusedLockState(sagaId, lockState);
+                throw new NonDurableSagaDeadlockException(sagaId);
+            }
+        }
+
+        try
+        {
+            lockState.Semaphore.Wait(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            lock (syncRoot)
+            {
+                waitingOwners.Remove(ownerId);
+                lockState.WaiterCount--;
+                RemoveUnusedLockState(sagaId, lockState);
+            }
+
+            throw;
+        }
+        catch
+        {
+            lock (syncRoot)
+            {
+                waitingOwners.Remove(ownerId);
+                lockState.WaiterCount--;
+                RemoveUnusedLockState(sagaId, lockState);
+            }
+
+            throw;
+        }
+
+        lock (syncRoot)
+        {
+            waitingOwners.Remove(ownerId);
+            lockState.WaiterCount--;
+
+            if (lockState.OwnerId is not null)
+            {
+                throw new InvalidOperationException($"The saga lock for Id[{sagaId}] was acquired while it was still owned.");
+            }
+
+            lockState.OwnerId = ownerId;
+            lockState.ReentrancyCount = 1;
+            return new SagaLockLease(this, ownerId, sagaId);
+        }
+    }
+
+    void Release(Guid ownerId, Guid sagaId)
+    {
+        lock (syncRoot)
+        {
+            if (!lockStates.TryGetValue(sagaId, out var lockState))
+            {
+                throw new InvalidOperationException($"The saga lock for Id[{sagaId}] is not registered.");
+            }
+
+            if (lockState.OwnerId != ownerId)
+            {
+                throw new InvalidOperationException($"The saga lock for Id[{sagaId}] is owned by another session.");
+            }
+
+            lockState.ReentrancyCount--;
+
+            if (lockState.ReentrancyCount == 0)
+            {
+                lockState.OwnerId = null;
+                lockState.Semaphore.Release();
+                RemoveUnusedLockState(sagaId, lockState);
+            }
+        }
+    }
+
+    SagaLockState GetOrAddLockState(Guid sagaId)
+    {
+        if (lockStates.TryGetValue(sagaId, out var existing))
+        {
+            return existing;
+        }
+
+        var created = new SagaLockState();
+        lockStates.Add(sagaId, created);
+        return created;
+    }
+
+    bool CreatesCycle(Guid waitingOwnerId, Guid blockingOwnerId)
+    {
+        var visited = new HashSet<Guid> { waitingOwnerId };
+        var currentOwnerId = blockingOwnerId;
+
+        while (true)
+        {
+            if (!visited.Add(currentOwnerId))
+            {
+                return currentOwnerId == waitingOwnerId;
+            }
+
+            if (!waitingOwners.TryGetValue(currentOwnerId, out var nextOwnerId))
+            {
+                return false;
+            }
+
+            currentOwnerId = nextOwnerId;
+        }
+    }
+
+    void RemoveUnusedLockState(Guid sagaId, SagaLockState lockState)
+    {
+        if (lockState.OwnerId is null && lockState.ReentrancyCount == 0 && lockState.WaiterCount == 0)
+        {
+            lockStates.Remove(sagaId);
+        }
+    }
+
+    readonly object syncRoot = new();
+    readonly Dictionary<Guid, SagaLockState> lockStates = [];
+    readonly Dictionary<Guid, Guid> waitingOwners = [];
+
+    sealed class SagaLockLease(SagaLockManager manager, Guid ownerId, Guid sagaId) : IDisposable
+    {
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref disposed, 1) != 0)
+            {
+                return;
+            }
+
+            manager.Release(ownerId, sagaId);
+        }
+
+        int disposed;
+    }
+
+    sealed class SagaLockState
+    {
+        public Guid? OwnerId { get; set; }
+
+        public int ReentrancyCount { get; set; }
+
+        public int WaiterCount { get; set; }
+
+        public SemaphoreSlim Semaphore { get; } = new(1, 1);
+    }
+}

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaLockingSessionState.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaLockingSessionState.cs
@@ -1,0 +1,51 @@
+namespace NServiceBus.Persistence.NonDurable.SagaPersister;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+sealed class SagaLockingSessionState(NonDurableStorage storage) : INonDurableSagaLockingSession
+{
+    public bool UsesPessimisticSagaConcurrency => storage.SagaConcurrencyMode == NonDurableSagaConcurrencyMode.Pessimistic;
+
+    public bool TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken = default)
+    {
+        if (storage.SagaConcurrencyMode != NonDurableSagaConcurrencyMode.Pessimistic || acquiredSagaLocks.ContainsKey(sagaId))
+        {
+            return false;
+        }
+
+        var lockLease = storage.SagaLocks.Acquire(lockOwnerId, sagaId, cancellationToken);
+        acquiredSagaLocks.Add(sagaId, lockLease);
+        return true;
+    }
+
+    public void ReleaseSagaLock(Guid sagaId)
+    {
+        if (acquiredSagaLocks.Remove(sagaId, out var lockLease))
+        {
+            lockLease.Dispose();
+        }
+    }
+
+    public void ReleaseAllSagaLocks()
+    {
+        if (sagaLocksReleased)
+        {
+            return;
+        }
+
+        foreach (var lockLease in acquiredSagaLocks.Values)
+        {
+            lockLease.Dispose();
+        }
+
+        acquiredSagaLocks.Clear();
+        sagaLocksReleased = true;
+    }
+
+    bool sagaLocksReleased;
+    // Session-local, only used by a single message flow.
+    readonly Dictionary<Guid, IDisposable> acquiredSagaLocks = [];
+    readonly Guid lockOwnerId = Guid.NewGuid();
+}

--- a/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaReadLocking.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SagaPersister/SagaReadLocking.cs
@@ -1,0 +1,50 @@
+namespace NServiceBus.Persistence.NonDurable.SagaPersister;
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+static class SagaReadLocking
+{
+    public static TSagaData? ReadCurrent<TSagaData>(
+        ConcurrentDictionary<Guid, SagaEntry> sagas,
+        INonDurableSagaLockingSession lockingSession,
+        Guid sagaId,
+        Func<SagaEntry, TSagaData?> tryRead,
+        Action<Guid, SagaEntry> captureEntry,
+        CancellationToken cancellationToken = default)
+        where TSagaData : class, IContainSagaData
+    {
+        ArgumentNullException.ThrowIfNull(sagas);
+        ArgumentNullException.ThrowIfNull(lockingSession);
+        ArgumentNullException.ThrowIfNull(tryRead);
+        ArgumentNullException.ThrowIfNull(captureEntry);
+
+        var lockAcquired = lockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
+
+        try
+        {
+            if (sagas.TryGetValue(sagaId, out var entry) && tryRead(entry) is { } sagaData)
+            {
+                captureEntry(sagaId, entry);
+                return sagaData;
+            }
+        }
+        catch
+        {
+            if (lockAcquired)
+            {
+                lockingSession.ReleaseSagaLock(sagaId);
+            }
+
+            throw;
+        }
+
+        if (lockAcquired)
+        {
+            lockingSession.ReleaseSagaLock(sagaId);
+        }
+
+        return null;
+    }
+}

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -174,6 +174,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
     bool ownsTransaction;
     bool enlistedInAmbientTransaction;
     bool sagaLocksReleased;
+    // Session-local, only used used by a single message flow
     readonly Dictionary<Guid, IDisposable> acquiredSagaLocks = [];
     readonly Guid lockOwnerId = Guid.NewGuid();
     readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -11,10 +11,17 @@ using Persistence;
 using SagaPersister;
 using Transport;
 
-class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : ICompletableSynchronizedStorageSession, INonDurableStorageSession, INonDurableSagaLockingSession
+class NonDurableSynchronizedStorageSession : ICompletableSynchronizedStorageSession, INonDurableStorageSession, INonDurableSagaLockingSession
 {
     public NonDurableSynchronizedStorageSession() : this(NonDurableStorageRuntime.SharedOptimisticStorage)
     {
+    }
+
+    public NonDurableSynchronizedStorageSession(NonDurableStorage storage)
+    {
+        this.storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        sagaLockingSession = new SagaLockingSessionState(this.storage);
+        completionCallbacks.Add(sagaLockingSession.ReleaseAllSagaLocks);
     }
 
     public NonDurableStorageTransaction? Transaction { get; private set; }
@@ -31,7 +38,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
             if (ownsTransaction && !enlistedInAmbientTransaction)
             {
                 tx.DisposeTrackedActivities();
-                sagaLockingSession.ReleaseAllSagaLocks();
+                completionCallbacks.Run();
             }
 
             Transaction = null;
@@ -51,7 +58,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         {
             Transaction = nonDurableOutboxTransaction.Transaction;
             ownsTransaction = false;
-            nonDurableOutboxTransaction.OnCompleted(sagaLockingSession.ReleaseAllSagaLocks);
+            nonDurableOutboxTransaction.OnCompleted(completionCallbacks.Run);
             return new ValueTask<bool>(true);
         }
 
@@ -88,7 +95,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         Transaction = new NonDurableStorageTransaction();
         ownsTransaction = true;
         enlistedInAmbientTransaction = true;
-        enlistmentNotification = new EnlistmentNotification(Transaction, sagaLockingSession.ReleaseAllSagaLocks);
+        enlistmentNotification = new EnlistmentNotification(Transaction, completionCallbacks.Run);
         ambientTransaction.EnlistVolatile(enlistmentNotification, EnlistmentOptions.None);
         return new ValueTask<bool>(true);
     }
@@ -110,7 +117,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
             }
             finally
             {
-                sagaLockingSession.ReleaseAllSagaLocks();
+                completionCallbacks.Run();
             }
         }
 
@@ -141,8 +148,9 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
 
     bool ownsTransaction;
     bool enlistedInAmbientTransaction;
-    readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));
-    readonly SagaLockingSessionState sagaLockingSession = new(storage ?? throw new ArgumentNullException(nameof(storage)));
+    readonly NonDurableStorage storage;
+    readonly SagaLockingSessionState sagaLockingSession;
+    readonly CompletionCallbacks completionCallbacks = new();
 
     internal class EnlistmentNotification(NonDurableStorageTransaction transaction, Action releaseSagaLocks) : IEnlistmentNotification
     {

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Persistence.NonDurable;
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,11 +9,12 @@ using System.Transactions;
 using Extensibility;
 using Outbox;
 using Persistence;
+using SagaPersister;
 using Transport;
 
-class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : ICompletableSynchronizedStorageSession, INonDurableStorageSession
+class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : ICompletableSynchronizedStorageSession, INonDurableStorageSession, INonDurableSagaLockingSession
 {
-    public NonDurableSynchronizedStorageSession() : this(NonDurableStorageRuntime.SharedStorage)
+    public NonDurableSynchronizedStorageSession() : this(NonDurableStorageRuntime.SharedOptimisticStorage)
     {
     }
 
@@ -30,6 +32,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
             if (ownsTransaction && !enlistedInAmbientTransaction)
             {
                 tx.DisposeTrackedActivities();
+                ReleaseSagaLocks();
             }
 
             Transaction = null;
@@ -49,6 +52,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         {
             Transaction = nonDurableOutboxTransaction.Transaction;
             ownsTransaction = false;
+            nonDurableOutboxTransaction.OnCompleted(ReleaseSagaLocks);
             return new ValueTask<bool>(true);
         }
 
@@ -85,7 +89,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         Transaction = new NonDurableStorageTransaction();
         ownsTransaction = true;
         enlistedInAmbientTransaction = true;
-        enlistmentNotification = new EnlistmentNotification(Transaction);
+        enlistmentNotification = new EnlistmentNotification(Transaction, ReleaseSagaLocks);
         ambientTransaction.EnlistVolatile(enlistmentNotification, EnlistmentOptions.None);
         return new ValueTask<bool>(true);
     }
@@ -101,7 +105,14 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
     {
         if (ownsTransaction && !enlistedInAmbientTransaction && Transaction is not null)
         {
-            Transaction.Commit();
+            try
+            {
+                Transaction.Commit();
+            }
+            finally
+            {
+                ReleaseSagaLocks();
+            }
         }
 
         return Task.CompletedTask;
@@ -116,16 +127,58 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
 
     public TSagaData? GetSagaData<TSagaData>(IReadOnlyContextBag context, Func<TSagaData, bool> predicate, CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
-        NonDurableSagaDataProjection.GetSagaData(storage, context, predicate, cancellationToken);
+        NonDurableSagaDataProjection.GetSagaData(storage, this, context, predicate, cancellationToken);
 
     public TSagaData? GetSagaData<TSagaData, TState>(IReadOnlyContextBag context, TState state, Func<TSagaData, TState, bool> predicate, CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
-        NonDurableSagaDataProjection.GetSagaData(storage, context, state, predicate, cancellationToken);
+        NonDurableSagaDataProjection.GetSagaData(storage, this, context, state, predicate, cancellationToken);
+
+    bool INonDurableSagaLockingSession.UsesPessimisticSagaConcurrency => storage.SagaConcurrencyMode == NonDurableSagaConcurrencyMode.Pessimistic;
+
+    bool INonDurableSagaLockingSession.TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken)
+    {
+        if (storage.SagaConcurrencyMode != NonDurableSagaConcurrencyMode.Pessimistic || acquiredSagaLocks.ContainsKey(sagaId))
+        {
+            return false;
+        }
+
+        var lockLease = storage.SagaLocks.Acquire(lockOwnerId, sagaId, cancellationToken);
+        acquiredSagaLocks.Add(sagaId, lockLease);
+        return true;
+    }
+
+    void INonDurableSagaLockingSession.ReleaseSagaLock(Guid sagaId)
+    {
+        if (acquiredSagaLocks.Remove(sagaId, out var lockLease))
+        {
+            lockLease.Dispose();
+        }
+    }
+
+    void ReleaseSagaLocks()
+    {
+        if (sagaLocksReleased)
+        {
+            return;
+        }
+
+        foreach (var lockLease in acquiredSagaLocks.Values)
+        {
+            lockLease.Dispose();
+        }
+
+        acquiredSagaLocks.Clear();
+        sagaLocksReleased = true;
+    }
 
     bool ownsTransaction;
     bool enlistedInAmbientTransaction;
+    bool sagaLocksReleased;
+    readonly Dictionary<Guid, IDisposable> acquiredSagaLocks = [];
+    readonly Guid lockOwnerId = Guid.NewGuid();
+    readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));
 
-    internal class EnlistmentNotification(NonDurableStorageTransaction transaction) : IEnlistmentNotification
+    internal class EnlistmentNotification(NonDurableStorageTransaction transaction, Action releaseSagaLocks) : IEnlistmentNotification
     {
         public TaskCompletionSource TransactionCompletionSource { get; } = new();
 
@@ -145,6 +198,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
 
         public void Commit(Enlistment enlistment)
         {
+            releaseSagaLocks();
             enlistment.Done();
             TransactionCompletionSource.SetResult();
         }
@@ -152,10 +206,15 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         public void Rollback(Enlistment enlistment)
         {
             transaction.Rollback();
+            releaseSagaLocks();
             enlistment.Done();
             TransactionCompletionSource.SetResult();
         }
 
-        public void InDoubt(Enlistment enlistment) => enlistment.Done();
+        public void InDoubt(Enlistment enlistment)
+        {
+            releaseSagaLocks();
+            enlistment.Done();
+        }
     }
 }

--- a/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Persistence.NonDurable;
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +31,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
             if (ownsTransaction && !enlistedInAmbientTransaction)
             {
                 tx.DisposeTrackedActivities();
-                ReleaseSagaLocks();
+                sagaLockingSession.ReleaseAllSagaLocks();
             }
 
             Transaction = null;
@@ -52,7 +51,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         {
             Transaction = nonDurableOutboxTransaction.Transaction;
             ownsTransaction = false;
-            nonDurableOutboxTransaction.OnCompleted(ReleaseSagaLocks);
+            nonDurableOutboxTransaction.OnCompleted(sagaLockingSession.ReleaseAllSagaLocks);
             return new ValueTask<bool>(true);
         }
 
@@ -89,7 +88,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         Transaction = new NonDurableStorageTransaction();
         ownsTransaction = true;
         enlistedInAmbientTransaction = true;
-        enlistmentNotification = new EnlistmentNotification(Transaction, ReleaseSagaLocks);
+        enlistmentNotification = new EnlistmentNotification(Transaction, sagaLockingSession.ReleaseAllSagaLocks);
         ambientTransaction.EnlistVolatile(enlistmentNotification, EnlistmentOptions.None);
         return new ValueTask<bool>(true);
     }
@@ -111,7 +110,7 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
             }
             finally
             {
-                ReleaseSagaLocks();
+                sagaLockingSession.ReleaseAllSagaLocks();
             }
         }
 
@@ -133,51 +132,17 @@ class NonDurableSynchronizedStorageSession(NonDurableStorage storage) : IComplet
         where TSagaData : class, IContainSagaData =>
         NonDurableSagaDataProjection.GetSagaData(storage, this, context, state, predicate, cancellationToken);
 
-    bool INonDurableSagaLockingSession.UsesPessimisticSagaConcurrency => storage.SagaConcurrencyMode == NonDurableSagaConcurrencyMode.Pessimistic;
+    bool INonDurableSagaLockingSession.UsesPessimisticSagaConcurrency => sagaLockingSession.UsesPessimisticSagaConcurrency;
 
-    bool INonDurableSagaLockingSession.TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken)
-    {
-        if (storage.SagaConcurrencyMode != NonDurableSagaConcurrencyMode.Pessimistic || acquiredSagaLocks.ContainsKey(sagaId))
-        {
-            return false;
-        }
+    bool INonDurableSagaLockingSession.TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken) =>
+        sagaLockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
 
-        var lockLease = storage.SagaLocks.Acquire(lockOwnerId, sagaId, cancellationToken);
-        acquiredSagaLocks.Add(sagaId, lockLease);
-        return true;
-    }
-
-    void INonDurableSagaLockingSession.ReleaseSagaLock(Guid sagaId)
-    {
-        if (acquiredSagaLocks.Remove(sagaId, out var lockLease))
-        {
-            lockLease.Dispose();
-        }
-    }
-
-    void ReleaseSagaLocks()
-    {
-        if (sagaLocksReleased)
-        {
-            return;
-        }
-
-        foreach (var lockLease in acquiredSagaLocks.Values)
-        {
-            lockLease.Dispose();
-        }
-
-        acquiredSagaLocks.Clear();
-        sagaLocksReleased = true;
-    }
+    void INonDurableSagaLockingSession.ReleaseSagaLock(Guid sagaId) => sagaLockingSession.ReleaseSagaLock(sagaId);
 
     bool ownsTransaction;
     bool enlistedInAmbientTransaction;
-    bool sagaLocksReleased;
-    // Session-local, only used used by a single message flow
-    readonly Dictionary<Guid, IDisposable> acquiredSagaLocks = [];
-    readonly Guid lockOwnerId = Guid.NewGuid();
     readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));
+    readonly SagaLockingSessionState sagaLockingSession = new(storage ?? throw new ArgumentNullException(nameof(storage)));
 
     internal class EnlistmentNotification(NonDurableStorageTransaction transaction, Action releaseSagaLocks) : IEnlistmentNotification
     {

--- a/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Testing;
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using Extensibility;
 using Persistence;
@@ -58,32 +57,16 @@ public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage stor
         where TSagaData : class, IContainSagaData =>
         NonDurableSagaDataProjection.GetSagaData(storage, this, context, state, predicate, cancellationToken);
 
-    bool INonDurableSagaLockingSession.UsesPessimisticSagaConcurrency => storage.SagaConcurrencyMode == NonDurableSagaConcurrencyMode.Pessimistic;
+    bool INonDurableSagaLockingSession.UsesPessimisticSagaConcurrency => sagaLockingSession.UsesPessimisticSagaConcurrency;
 
-    bool INonDurableSagaLockingSession.TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken)
-    {
-        if (storage.SagaConcurrencyMode != NonDurableSagaConcurrencyMode.Pessimistic || acquiredSagaLocks.ContainsKey(sagaId))
-        {
-            return false;
-        }
+    bool INonDurableSagaLockingSession.TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken) =>
+        sagaLockingSession.TryAcquireSagaLock(sagaId, cancellationToken);
 
-        var lockLease = storage.SagaLocks.Acquire(lockOwnerId, sagaId, cancellationToken);
-        acquiredSagaLocks.Add(sagaId, lockLease);
-        return true;
-    }
-
-    void INonDurableSagaLockingSession.ReleaseSagaLock(Guid sagaId)
-    {
-        if (acquiredSagaLocks.Remove(sagaId, out var lockLease))
-        {
-            lockLease.Dispose();
-        }
-    }
+    void INonDurableSagaLockingSession.ReleaseSagaLock(Guid sagaId) => sagaLockingSession.ReleaseSagaLock(sagaId);
 
     readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));
     readonly NonDurableSagaOptions sagaOptions = sagaOptions ?? throw new ArgumentNullException(nameof(sagaOptions));
-    readonly Dictionary<Guid, IDisposable> acquiredSagaLocks = [];
-    readonly Guid lockOwnerId = Guid.NewGuid();
+    readonly SagaLockingSessionState sagaLockingSession = new(storage ?? throw new ArgumentNullException(nameof(storage)));
 
     static NonDurableStorage CreateStorage(NonDurableSagaOptions sagaOptions)
     {

--- a/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Persistence.NonDurable/Testing/TestableNonDurableSynchronizedStorageSession.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Testing;
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Extensibility;
 using Persistence;
@@ -13,7 +14,7 @@ using Persistence.NonDurable.SagaPersister;
 /// <remarks>
 /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using the specified storage instance and saga options.
 /// </remarks>
-public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage storage, NonDurableSagaOptions sagaOptions) : ISynchronizedStorageSession, INonDurableStorageSession
+public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage storage, NonDurableSagaOptions sagaOptions) : ISynchronizedStorageSession, INonDurableStorageSession, INonDurableSagaLockingSession
 {
     /// <summary>
     /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using a new <see cref="NonDurableStorage" /> instance and default saga options.
@@ -25,7 +26,7 @@ public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage stor
     /// <summary>
     /// Initializes a new instance of <see cref="TestableNonDurableSynchronizedStorageSession" /> using a new <see cref="NonDurableStorage" /> instance and the specified saga options.
     /// </summary>
-    public TestableNonDurableSynchronizedStorageSession(NonDurableSagaOptions sagaOptions) : this(new NonDurableStorage(), sagaOptions)
+    public TestableNonDurableSynchronizedStorageSession(NonDurableSagaOptions sagaOptions) : this(CreateStorage(sagaOptions), sagaOptions)
     {
     }
 
@@ -50,13 +51,47 @@ public class TestableNonDurableSynchronizedStorageSession(NonDurableStorage stor
     /// <inheritdoc />
     public TSagaData? GetSagaData<TSagaData>(IReadOnlyContextBag context, Func<TSagaData, bool> predicate, CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
-        NonDurableSagaDataProjection.GetSagaData(storage, context, predicate, cancellationToken);
+        NonDurableSagaDataProjection.GetSagaData(storage, this, context, predicate, cancellationToken);
 
     /// <inheritdoc />
     public TSagaData? GetSagaData<TSagaData, TState>(IReadOnlyContextBag context, TState state, Func<TSagaData, TState, bool> predicate, CancellationToken cancellationToken = default)
         where TSagaData : class, IContainSagaData =>
-        NonDurableSagaDataProjection.GetSagaData(storage, context, state, predicate, cancellationToken);
+        NonDurableSagaDataProjection.GetSagaData(storage, this, context, state, predicate, cancellationToken);
+
+    bool INonDurableSagaLockingSession.UsesPessimisticSagaConcurrency => storage.SagaConcurrencyMode == NonDurableSagaConcurrencyMode.Pessimistic;
+
+    bool INonDurableSagaLockingSession.TryAcquireSagaLock(Guid sagaId, CancellationToken cancellationToken)
+    {
+        if (storage.SagaConcurrencyMode != NonDurableSagaConcurrencyMode.Pessimistic || acquiredSagaLocks.ContainsKey(sagaId))
+        {
+            return false;
+        }
+
+        var lockLease = storage.SagaLocks.Acquire(lockOwnerId, sagaId, cancellationToken);
+        acquiredSagaLocks.Add(sagaId, lockLease);
+        return true;
+    }
+
+    void INonDurableSagaLockingSession.ReleaseSagaLock(Guid sagaId)
+    {
+        if (acquiredSagaLocks.Remove(sagaId, out var lockLease))
+        {
+            lockLease.Dispose();
+        }
+    }
 
     readonly NonDurableStorage storage = storage ?? throw new ArgumentNullException(nameof(storage));
     readonly NonDurableSagaOptions sagaOptions = sagaOptions ?? throw new ArgumentNullException(nameof(sagaOptions));
+    readonly Dictionary<Guid, IDisposable> acquiredSagaLocks = [];
+    readonly Guid lockOwnerId = Guid.NewGuid();
+
+    static NonDurableStorage CreateStorage(NonDurableSagaOptions sagaOptions)
+    {
+        ArgumentNullException.ThrowIfNull(sagaOptions);
+
+        return new NonDurableStorage(new NonDurableStorageOptions
+        {
+            SagaConcurrencyMode = sagaOptions.ConcurrencyMode
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in pessimistic saga concurrency mode to `NServiceBus.Persistence.NonDurable` while keeping the existing optimistic behavior as the default.

This brings the non-durable saga persister closer to SQL Persistence semantics for **existing saga instances**:

- saga reads can now take an exclusive per-saga lock and hold it for the synchronized storage session lifetime
- updates and completes still keep the existing optimistic concurrency check as a correctness backstop
- missing correlated saga instances are **not** pre-locked on create paths, matching SQL Persistence behavior

## What changed

### Pessimistic saga concurrency mode

Introduced `NonDurableSagaConcurrencyMode` with:

- `Optimistic` (default)
- `Pessimistic`

`NonDurableSagaOptions.ConcurrencyMode` remains the persister-facing setting, and `NonDurableStorageOptions.SagaConcurrencyMode` now makes the storage-level decision explicit and immutable.

### Storage-scoped lock manager

Added a storage-owned `SagaLockManager` that:

- maintains per-saga exclusive locks
- scopes locking to the shared `NonDurableStorage` instance rather than to a single persister instance
- detects deadlocks using a wait-for graph and fails the victim with a dedicated deadlock exception

This allows multiple persister/session users that share the same in-memory store to participate in the same locking domain.

### Session-owned lock lifetime

Updated synchronized storage sessions to:

- acquire saga locks on read when the backing storage is configured for pessimistic concurrency
- hold acquired locks for the full transaction/session lifetime
- release locks on commit, rollback, disposal, ambient transaction completion, and outbox-backed session completion

### Saga read integration

Pessimistic locking is now applied to existing saga loads across all relevant read paths:

- `Get<TSagaData>(Guid sagaId, ...)`
- `Get<TSagaData>(string propertyName, object propertyValue, ...)`
- projection/custom-finder reads via `INonDurableStorageSession.GetSagaData(...)`

For projection-based reads, the persister now re-reads and re-checks the live entry after acquiring the lock so the returned saga data reflects the locked state.

### Storage-mode consistency

The storage now owns its effective saga concurrency mode. Persister construction validates that the requested saga concurrency mode matches the configured `NonDurableStorage` mode and throws on mismatch.

The runtime also keeps separate shared default storage instances for optimistic and pessimistic saga modes so endpoints using the default shared store do not accidentally mix locking behaviors.

## Tests

Added and updated coverage for:

- pessimistic reads blocking until the current holder commits
- pessimistic reads observing the latest committed saga state after waiting
- deadlock detection when two sessions wait on each other
- rejection of conflicting saga concurrency modes on shared storage
- custom finder / projection-based saga retrieval continuing to work with the new locking path
